### PR TITLE
Add argparse CLI for single video, playlist and channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,9 @@ Each agent groups related functions and responsibilities.
 ## CLI Agent
 **Purpose**: Provide the command line interface and dispatch user choices.
 
-**Entry point**: `main()` in [main.py](main.py) lines 11-70.
+**Entry point**: `main()` in [main.py](main.py) lines 128-150.
 
-**Inputs**: user selections from the menu.
+**Inputs**: command-line arguments or user selections from the menu.
 
 **Outputs**: invokes download functions and terminates when the user chooses to quit.
 


### PR DESCRIPTION
## Summary
- expose a new `main()` that parses subcommands with argparse
- move interactive loop to a `menu()` function
- document new CLI entry in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842e1e1d2908321805c5bfd4ff2d7d0