### PR TITLE
Inject callbacks into downloader

### DIFF
--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -65,13 +65,27 @@ def menu() -> None:
                 if reponse_utilisateur_pour_choix_dans_menu == 1:
                     download_sound_only = False
 
-                yd.download_multiple_videos(url_video_send_user_list, download_sound_only)
+                save_path = youtube_downloader.demander_save_file_path()
+                yd.download_multiple_videos(
+                    url_video_send_user_list,
+                    download_sound_only,
+                    save_path=save_path,
+                    choice_callback=youtube_downloader.demander_choice_resolution_vidéo_or_bitrate_audio,
+                    progress_callback=youtube_downloader.on_download_progress,
+                )
             case 2 | 6:
                 youtube_video_links: list[str] = youtube_downloader.demander_youtube_link_file()
                 if reponse_utilisateur_pour_choix_dans_menu == 2:
                     download_sound_only = False
 
-                yd.download_multiple_videos(youtube_video_links, download_sound_only)
+                save_path = youtube_downloader.demander_save_file_path()
+                yd.download_multiple_videos(
+                    youtube_video_links,
+                    download_sound_only,
+                    save_path=save_path,
+                    choice_callback=youtube_downloader.demander_choice_resolution_vidéo_or_bitrate_audio,
+                    progress_callback=youtube_downloader.on_download_progress,
+                )
             case 3 | 7:
                 url_playlist_send_user: str = youtube_downloader.ask_youtube_url()
                 try:
@@ -82,7 +96,14 @@ def menu() -> None:
                     if reponse_utilisateur_pour_choix_dans_menu == 3:
                         download_sound_only = False
 
-                    yd.download_multiple_videos(link_url_playlist_youtube, download_sound_only)  # type: ignore
+                    save_path = youtube_downloader.demander_save_file_path()
+                    yd.download_multiple_videos(
+                        link_url_playlist_youtube,
+                        download_sound_only,
+                        save_path=save_path,
+                        choice_callback=youtube_downloader.demander_choice_resolution_vidéo_or_bitrate_audio,
+                        progress_callback=youtube_downloader.on_download_progress,
+                    )  # type: ignore
             case 4 | 8:
                 url_channel_send_user: str = youtube_downloader.ask_youtube_url()
                 try:
@@ -93,7 +114,14 @@ def menu() -> None:
                     if reponse_utilisateur_pour_choix_dans_menu == 4:
                         download_sound_only = False
 
-                    yd.download_multiple_videos(link_url_channel_youtube, download_sound_only)  # type: ignore
+                    save_path = youtube_downloader.demander_save_file_path()
+                    yd.download_multiple_videos(
+                        link_url_channel_youtube,
+                        download_sound_only,
+                        save_path=save_path,
+                        choice_callback=youtube_downloader.demander_choice_resolution_vidéo_or_bitrate_audio,
+                        progress_callback=youtube_downloader.on_download_progress,
+                    )  # type: ignore
 
     
 # import sys
@@ -139,13 +167,34 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if command == "video":
-        yd.download_multiple_videos(args.urls, args.audio)
+        save_path = youtube_downloader.demander_save_file_path()
+        yd.download_multiple_videos(
+            args.urls,
+            args.audio,
+            save_path=save_path,
+            choice_callback=youtube_downloader.demander_choice_resolution_vidéo_or_bitrate_audio,
+            progress_callback=youtube_downloader.on_download_progress,
+        )
     elif command == "playlist":
         playlist = youtube_downloader.Playlist(args.url)
-        yd.download_multiple_videos(playlist, args.audio)  # type: ignore
+        save_path = youtube_downloader.demander_save_file_path()
+        yd.download_multiple_videos(
+            playlist,
+            args.audio,
+            save_path=save_path,
+            choice_callback=youtube_downloader.demander_choice_resolution_vidéo_or_bitrate_audio,
+            progress_callback=youtube_downloader.on_download_progress,
+        )  # type: ignore
     elif command == "channel":
         channel = youtube_downloader.Channel(args.url)
-        yd.download_multiple_videos(channel, args.audio)  # type: ignore
+        save_path = youtube_downloader.demander_save_file_path()
+        yd.download_multiple_videos(
+            channel,
+            args.audio,
+            save_path=save_path,
+            choice_callback=youtube_downloader.demander_choice_resolution_vidéo_or_bitrate_audio,
+            progress_callback=youtube_downloader.on_download_progress,
+        )  # type: ignore
     else:
         raise SystemExit(f"Unknown command: {command}")
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+from program_youtube_downloader import downloader as downloader_module
+from program_youtube_downloader.downloader import YoutubeDownloader
+
+class DummyStream:
+    itag = 1
+    resolution = "360p"
+    abr = "128kbps"
+    default_filename = "sample.mp4"
+
+    def download(self, output_path: str) -> str:
+        p = Path(output_path) / self.default_filename
+        p.write_text("data")
+        return str(p)
+
+class DummyStreams(list):
+    def get_by_itag(self, itag: int) -> DummyStream:
+        return self[0]
+
+class DummyYT:
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self.title = "video"
+        self.streams: DummyStreams = DummyStreams([DummyStream()])
+        self.progress = None
+
+    def register_on_progress_callback(self, cb) -> None:
+        self.progress = cb
+
+def test_download_multiple_videos_custom_callbacks(monkeypatch, tmp_path: Path) -> None:
+    created = {}
+
+    def fake_constructor(url: str) -> DummyYT:
+        yt = DummyYT(url)
+        created['yt'] = yt
+        return yt
+
+    monkeypatch.setattr(downloader_module, "YouTube", fake_constructor)
+    monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
+    monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
+    monkeypatch.setattr(downloader_module, "program_break_time", lambda *a, **k: None)
+    monkeypatch.setattr(downloader_module, "clear_screen", lambda *a, **k: None)
+
+    called = {}
+
+    def choice_cb(sound_only: bool, streams) -> int:
+        called['choice'] = True
+        return 1
+
+    def progress_cb(stream, chunk, bytes_remaining) -> None:
+        called['progress'] = True
+
+    yd = YoutubeDownloader()
+    yd.download_multiple_videos([
+        "https://youtu.be/dummy"
+    ], False, save_path=tmp_path, choice_callback=choice_cb, progress_callback=progress_cb)
+
+    assert (tmp_path / "sample.mp4").exists()
+    assert created['yt'].progress is progress_cb
+    assert called['choice']


### PR DESCRIPTION
## Summary
- accept optional callbacks and save path in `YoutubeDownloader`
- pass callbacks through CLI layer
- add tests for new callback parameters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842ecf9748883218699c04049853677