### PR TITLE
Improve logging for error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,26 @@ consultez [AGENTS.md](AGENTS.md).
 
 Ce projet est destiné à un usage personnel pour faciliter la récupération de contenu YouTube.
 
+## Journalisation
+
+L'outil utilise le module `logging` de Python pour afficher les messages d'erreur.
+Par défaut, seuls les messages de niveau `ERROR` sont affichés. Vous pouvez
+activer un niveau plus verbeux de deux manières&nbsp;:
+
+1. En définissant la variable d'environnement `PYDL_LOG_LEVEL` avant d'exécuter
+   le programme&nbsp;:
+
+   ```bash
+   PYDL_LOG_LEVEL=DEBUG python main.py video https://youtu.be/example
+   ```
+
+2. Ou en utilisant l'option de ligne de commande `--log-level` qui prend le
+   pas sur la variable d'environnement&nbsp;:
+
+   ```bash
+   python main.py --log-level INFO video https://youtu.be/example
+   ```
+
 ## Tests
 
 Les tests unitaires sont écrits avec `pytest`. Après l’installation des dépendances, exécutez :

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -31,14 +31,17 @@ class YoutubeDownloader:
                 )
             return streams
         except HTTPError as e:
-            print(
-                f"[ERREUR] : Impossible d'accéder aux flux pour la vidéo. Code HTTP : {e.code}, Message : {e.reason}"
+            logging.error(
+                "[ERREUR] : Impossible d'accéder aux flux pour la vidéo. Code HTTP : %s, Message : %s",
+                e.code,
+                e.reason,
             )
             return None
         except Exception as e:  # pragma: no cover - defensive
             logging.exception("Unexpected error while retrieving streams")
-            print(
-                f"[ERREUR] : Une erreur inattendue s'est produite lors de la récupération des flux : {e}"
+            logging.error(
+                "[ERREUR] : Une erreur inattendue s'est produite lors de la récupération des flux : %s",
+                e,
             )
             return None
 
@@ -73,7 +76,7 @@ class YoutubeDownloader:
 
         url_list = list(url_youtube_video_links)
         if not url_list:
-            print("[ERREUR] : il y a aucune vidéo à télécharger")
+            logging.error("[ERREUR] : il y a aucune vidéo à télécharger")
             return url_list
 
         for url_video in url_list:
@@ -82,31 +85,35 @@ class YoutubeDownloader:
                 if progress_callback:
                     youtube_video.register_on_progress_callback(progress_callback)
             except KeyError as e:
-                print(f"[ERREUR] : Problème de clé dans les données : {e}")
+                logging.error("[ERREUR] : Problème de clé dans les données : %s", e)
                 continue
             except Exception as e:  # pragma: no cover - defensive
                 logging.exception("Unexpected error while connecting to video")
-                print(f"[ERREUR] : Connexion à la vidéo impossible : {e}")
+                logging.error("[ERREUR] : Connexion à la vidéo impossible : %s", e)
                 continue
 
             streams = self.streams_video(download_sound_only, youtube_video)
             if not streams:
-                print(
-                    f"[ERREUR] : Les flux pour la vidéo ({url_video}) n'ont pas pu être récupérés."
+                logging.error(
+                    "[ERREUR] : Les flux pour la vidéo (%s) n'ont pas pu être récupérés.",
+                    url_video,
                 )
                 continue
 
             try:
                 video_title = youtube_video.title
             except KeyError as e:
-                print(
-                    f"[ERREUR] : Impossible d'accéder au titre de la vidéo {url_video}. Détail : {e}"
+                logging.error(
+                    "[ERREUR] : Impossible d'accéder au titre de la vidéo %s. Détail : %s",
+                    url_video,
+                    e,
                 )
                 continue
             except Exception as e:  # pragma: no cover - defensive
                 logging.exception("Unexpected error while accessing video title")
-                print(
-                    f"[ERREUR] : Une erreur inattendue s'est produite lors de l'accès au titre : {e}"
+                logging.error(
+                    "[ERREUR] : Une erreur inattendue s'est produite lors de l'accès au titre : %s",
+                    e,
                 )
                 continue
 
@@ -142,7 +149,7 @@ class YoutubeDownloader:
             except Exception as e:  # pragma: no cover - network/io issues
                 logging.exception("Download failed")
                 print()
-                print(f"[ERREUR] : le téléchargement a échoué : {e}")
+                logging.error("[ERREUR] : le téléchargement a échoué : %s", e)
                 print()
                 continue
 

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -3,6 +3,7 @@
 import sys
 import argparse
 import logging
+import os
 
 if '__annotations__' not in globals():
     __annotations__ = {}
@@ -15,6 +16,12 @@ from .downloader import YoutubeDownloader
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Return the parsed CLI arguments."""
     parser = argparse.ArgumentParser(description="Program Youtube Downloader")
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("PYDL_LOG_LEVEL", "ERROR"),
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Set logging level (overrides PYDL_LOG_LEVEL)",
+    )
     subparsers = parser.add_subparsers(dest="command")
 
     video_parser = subparsers.add_parser("video", help="Download one or more videos")
@@ -163,6 +170,7 @@ def menu() -> None:
 def main(argv: list[str] | None = None) -> None:
     """Parse arguments and dispatch to subcommands."""
     args = parse_args(argv)
+    logging.getLogger().setLevel(args.log_level)
     command = args.command
     yd = YoutubeDownloader()
 

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -28,3 +28,15 @@ def test_parse_no_subcommand() -> None:
     args = parse_args([])
     assert args.command is None
 
+
+def test_parse_log_level_cli() -> None:
+    args = parse_args(["--log-level", "DEBUG", "video", "https://youtu.be/x"])
+    assert args.log_level == "DEBUG"
+    assert args.command == "video"
+
+
+def test_parse_log_level_env(monkeypatch) -> None:
+    monkeypatch.setenv("PYDL_LOG_LEVEL", "INFO")
+    args = parse_args(["video", "https://youtu.be/x"])
+    assert args.log_level == "INFO"
+


### PR DESCRIPTION
## Summary
- use `logging.error` instead of `print` for errors
- allow setting log level with `--log-level` or `PYDL_LOG_LEVEL`
- document logging configuration in README
- test CLI parsing for new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f35f8bb88321ab03fe7fcafd8924