### PR TITLE
Update README structure section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ Image :
 ## Structure du projet
 
 - `main.py` : point d’entrée du programme contenant la boucle de menu.
-- `youtube_downloader.py` : toutes les fonctions de téléchargement (gestion des flux, choix de qualité, conversion en MP3, etc.).
+- `downloader.py` : logique principale de téléchargement et conversions.
+- `cli_utils.py` : fonctions d'interaction utilisateur et gestion des menus.
+- `youtube_downloader.py` : constantes et utilitaires de progression.
 - `requirements.txt` : liste des dépendances Python nécessaires.
 - `mypy.ini` : configuration minimale pour `mypy`.
 


### PR DESCRIPTION
## Summary
- mention `downloader.py` logic and `cli_utils.py` helpers
- keep `main.py` as entry point in project structure section

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f4bddda883218de1a1571d46911b