### PR TITLE
Add constants module for CLI labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,8 @@ Each agent groups related functions and responsibilities.
 
 **Outputs**: invokes download functions and terminates when the user chooses to quit.
 
-**Dependencies**: `youtube_downloader` module.
+**Dependencies**: `youtube_downloader` module. Menu labels are defined in
+[`constants.py`](program_youtube_downloader/constants.py).
 
 Usage:
 ```python
@@ -81,6 +82,8 @@ Usage:
 **Inputs**: values typed by the user.
 
 **Outputs**: validated and sanitized inputs.
+Relies on `BASE_YOUTUBE_URL` from
+[`constants.py`](program_youtube_downloader/constants.py).
 
 Usage:
 ```python

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 import logging
 
-from .youtube_downloader import (
+from .constants import (
     TITLE_PROGRAM,
     TITLE_QUESTION_MENU_ACCUEIL,
     CHOICE_MENU_ACCUEIL,

--- a/program_youtube_downloader/constants.py
+++ b/program_youtube_downloader/constants.py
@@ -1,0 +1,17 @@
+TITLE_PROGRAM = "Program Youtube Downloader"
+
+TITLE_QUESTION_MENU_ACCUEIL = "Que voulez-vous télécharger sur Youtube ?"
+
+CHOICE_MENU_ACCUEIL: tuple[str, ...] = (
+    "une vidéo                              - (format mp4)",
+    "des vidéos                             - (format mp4)",
+    "une playlist vidéo                     - (format mp4)",
+    "des vidéos d'une chaîne Youtube        - (format mp4)",
+    "la piste audio d'une vidéo             - (format mp3)",
+    "les pistes audios de plusieurs vidéos  - (format mp3)",
+    "les pistes audios d'une playlist       - (format mp3)",
+    "les pistes audios d'une chaîne         - (format mp3)",
+    "Quitter le programme",
+)
+
+BASE_YOUTUBE_URL = "https://www.youtube.com"

--- a/program_youtube_downloader/youtube_downloader.py
+++ b/program_youtube_downloader/youtube_downloader.py
@@ -20,23 +20,12 @@ logging.basicConfig(level=logging.ERROR)
 # ------------------------------------------------------------------------------------------- #
 # ----------------------------------- CONSTANTES -------------------------------------------- #
 # ------------------------------------------------------------------------------------------- #
-TITLE_PROGRAM = "Program Youtube Downloader"
-
-TITLE_QUESTION_MENU_ACCUEIL = "Que voulez-vous télécharger sur Youtube ?"
-CHOICE_MENU_ACCUEIL : tuple[str, ...] = (
-        "une vidéo                              - (format mp4)",
-        "des vidéos                             - (format mp4)",
-        "une playlist vidéo                     - (format mp4)",
-        "des vidéos d'une chaîne Youtube        - (format mp4)",
-        "la piste audio d'une vidéo             - (format mp3)",
-        "les pistes audios de plusieurs vidéos  - (format mp3)",
-        "les pistes audios d'une playlist       - (format mp3)",
-        "les pistes audios d'une chaîne         - (format mp3)",
-        "Quitter le programme"
-        )
-
-# url de base de youtube:
-BASE_YOUTUBE_URL = "https://www.youtube.com"
+from .constants import (
+    TITLE_PROGRAM,
+    TITLE_QUESTION_MENU_ACCUEIL,
+    CHOICE_MENU_ACCUEIL,
+    BASE_YOUTUBE_URL,
+)
 
 # ------------------------------------------------------------------------------------------- #
 # ----------------------------------- FONCTIONS --------------------------------------------- #


### PR DESCRIPTION
## Summary
- extract menu and URL constants into `constants.py`
- update imports in CLI helpers and downloader
- document the new constants module in `AGENTS.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f968ae6483219c88136afc4a2873