### PR TITLE
Move progress callbacks to dedicated module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,8 +59,8 @@ conversion_mp4_in_mp3("video.mp4")
 **Purpose**: Display progress information while downloads are running.**
 
 **Entry points**:
-- `on_download_progress()` in [youtube_downloader.py](youtube_downloader.py) lines 174-183.
-- `progress_bar()` in [youtube_downloader.py](youtube_downloader.py) lines 186-208.
+- `on_download_progress()` in [program_youtube_downloader/progress.py](program_youtube_downloader/progress.py) lines 8-13.
+- `progress_bar()` in [program_youtube_downloader/progress.py](program_youtube_downloader/progress.py) lines 16-37.
 
 **Inputs**: stream callbacks from `pytubefix`, progress percentages.
 
@@ -98,7 +98,7 @@ choice = demander_valeur_numerique_utilisateur(1, 3)
 | CLI Agent | `main.py` | `main()` |
 | Download Agent | `downloader.py` | `download_multiple_videos` |
 | Conversion Agent | `youtube_downloader.py` | `conversion_mp4_in_mp3` |
-| Progress Agent | `youtube_downloader.py` | `on_download_progress`, `progress_bar` |
+| Progress Agent | `program_youtube_downloader/progress.py` | `on_download_progress`, `progress_bar` |
 | Validation Agent | `youtube_downloader.py` | `demander_valeur_numerique_utilisateur`, `demander_url_vidéo_youtube`, `demander_youtube_link_file` |
 
 ## Interaction Diagram

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -9,6 +9,7 @@ from .youtube_downloader import (
     program_break_time,
     clear_screen,
 )
+from .progress import on_download_progress
 from . import cli_utils
 
 
@@ -66,7 +67,7 @@ class YoutubeDownloader:
         *,
         save_path: Optional[Path] = None,
         choice_callback: Optional[Callable[[bool, Any], int]] = None,
-        progress_callback: Optional[Callable[[Any, Any, int], None]] = None,
+        progress_callback: Optional[Callable[[Any, Any, int], None]] = on_download_progress,
     ) -> Optional[list[str]]:
         """Download multiple YouTube videos or audio tracks."""
 

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -11,6 +11,7 @@ if '__annotations__' not in globals():
 from . import youtube_downloader
 from . import cli_utils
 from .downloader import YoutubeDownloader
+from .progress import on_download_progress
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -80,7 +81,7 @@ def menu() -> None:
                     download_sound_only,
                     save_path=save_path,
                     choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                    progress_callback=youtube_downloader.on_download_progress,
+                    progress_callback=on_download_progress,
                 )
             case 2 | 6:
                 youtube_video_links: list[str] = cli_utils.demander_youtube_link_file()
@@ -93,7 +94,7 @@ def menu() -> None:
                     download_sound_only,
                     save_path=save_path,
                     choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                    progress_callback=youtube_downloader.on_download_progress,
+                    progress_callback=on_download_progress,
                 )
             case 3 | 7:
                 url_playlist_send_user: str = cli_utils.ask_youtube_url()
@@ -112,7 +113,7 @@ def menu() -> None:
                         download_sound_only,
                         save_path=save_path,
                         choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                        progress_callback=youtube_downloader.on_download_progress,
+                        progress_callback=on_download_progress,
                     )  # type: ignore
             case 4 | 8:
                 url_channel_send_user: str = cli_utils.ask_youtube_url()
@@ -131,7 +132,7 @@ def menu() -> None:
                         download_sound_only,
                         save_path=save_path,
                         choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                        progress_callback=youtube_downloader.on_download_progress,
+                        progress_callback=on_download_progress,
                     )  # type: ignore
 
     
@@ -185,7 +186,7 @@ def main(argv: list[str] | None = None) -> None:
             args.audio,
             save_path=save_path,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-            progress_callback=youtube_downloader.on_download_progress,
+            progress_callback=on_download_progress,
         )
     elif command == "playlist":
         playlist = youtube_downloader.Playlist(args.url)
@@ -195,7 +196,7 @@ def main(argv: list[str] | None = None) -> None:
             args.audio,
             save_path=save_path,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-            progress_callback=youtube_downloader.on_download_progress,
+            progress_callback=on_download_progress,
         )  # type: ignore
     elif command == "channel":
         channel = youtube_downloader.Channel(args.url)
@@ -205,7 +206,7 @@ def main(argv: list[str] | None = None) -> None:
             args.audio,
             save_path=save_path,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-            progress_callback=youtube_downloader.on_download_progress,
+            progress_callback=on_download_progress,
         )  # type: ignore
     else:
         raise SystemExit(f"Unknown command: {command}")

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -1,0 +1,37 @@
+import sys
+import colorama
+from colorama import init
+
+init(autoreset=True)
+
+
+def on_download_progress(stream, chunk, bytes_remaining) -> None:
+    """Display progress percentage while downloading."""
+    total_bytes_download = stream.filesize
+    bytes_downloaded = stream.filesize - bytes_remaining
+    progress = (bytes_downloaded / total_bytes_download) * 100
+    progress_bar(progress)
+
+
+def progress_bar(
+    progress: float,
+    size: int = 35,
+    sides: str = "||",
+    full: str = "█",
+    empty: str = " ",
+    prefix_start: str = "Downloading ...",
+    prefix_end: str = "Download OK ...",
+    color_text: str = colorama.Fore.WHITE,
+    color_Downloading: str = colorama.Fore.LIGHTYELLOW_EX,
+    color_Download_OK: str = colorama.Fore.GREEN,
+) -> None:
+    """Print a textual progress bar to standard output."""
+    x = int(size * progress / 100)
+    bar = sides[0] + full * x + empty * (size - x) + sides[1]
+    sys.stdout.write(color_text + "\r" + prefix_start + color_Downloading + bar + f" {progress:.2f}% ")
+
+    if progress == 100:
+        sys.stdout.write("\r" + color_text + prefix_end + color_Download_OK + bar + f" {progress:.2f}% ")
+        print(colorama.Fore.RESET)
+
+    sys.stdout.flush()

--- a/program_youtube_downloader/youtube_downloader.py
+++ b/program_youtube_downloader/youtube_downloader.py
@@ -5,10 +5,6 @@ from pytube import Playlist
 from pytube import Channel
 import time
 import os
-import sys
-import colorama
-from colorama import init
-init(autoreset=True)
 from pathlib import Path
 import logging
 
@@ -44,43 +40,6 @@ def program_break_time(memorization_time:int, affichage_text:str) -> None:
         time.sleep(1)
         print(".", end="", flush=True)
         duree_restante_avant_lancement -= 1
-
-
-def on_download_progress(stream, chunk, bytes_remaining) -> None:
-    """ 
-    Fonction : 
-    - Quand il y a une progression dans le téléchargement
-    - Permet d'afficher les pourcentages restant à télécharger
-    """
-    total_bytes_download = stream.filesize
-    bytes_downloaded = stream.filesize - bytes_remaining
-    progress = (bytes_downloaded / total_bytes_download) * 100
-    progress_bar(progress)
-    
-
-def progress_bar(progress: float, size=35, sides="||", full='█', empty=' ' , prefix_start="Downloading ...", prefix_end = "Download OK ...", color_text=colorama.Fore.WHITE, color_Downloading=colorama.Fore.LIGHTYELLOW_EX, color_Download_OK=colorama.Fore.GREEN) -> None:
-    """
-        progress: Un nombre représentant l'état d'avancement, exprimé en pourcentage (de 00.00 à 100.00).
-        size: La taille totale de la barre de progression, exprimé en nombre de caractères utilisés pour afficher la barre (par défaut, 30).
-        sides: Les caractères utilisés pour dessiner les bords de la barre de progression (par défaut, "||").
-        full: Le caractère utilisé pour représenter la partie "remplie" de la bar de téléchargement. c'est la partie téléchargé (par défaut, "█").
-        empty: Le caractère utilisé pour représenter la partie "vide" de la bar de téléchargement. c'est la partie non téléchargée (par défaut, un espace).
-        prefix: Un texte optionnel à afficher avant la barre de progression (par défaut, "Downloading...").
-        color_text, color_Downloading, color_Download_OK: Des paramètres pour spécifier les couleurs du texte affiché.
-
-        variable (x) : multiplie la taille totale de la barre de progression (size) par la valeur décimale du pourcentage d'avancement (progress / 100).
-        Cela donne la position relative de la progression en fonction de la taille totale de la barre de progression. 
-        Par exemple, si (size) est de 30 caractères et (progress) est de 50%, cela donnerait 15, ce qui signifie que la moitié de la barre de progression doit être remplie. 
-    """
-    x = int(size * progress / 100)
-    bar = sides[0] + full * x + empty * (size - x) + sides[1]
-    sys.stdout.write(color_text + "\r" + prefix_start + color_Downloading + bar + f" {progress:.2f}% ")
-    
-    if progress == 100:
-        sys.stdout.write("\r" + color_text + prefix_end + color_Download_OK + bar + f" {progress:.2f}% ")
-        print(colorama.Fore.RESET)
-    
-    sys.stdout.flush()
 
 
 


### PR DESCRIPTION
## Summary
- add new `progress.py` module for callbacks
- import callbacks from `progress.py` in downloader and main
- default to using `on_download_progress` when downloading
- document new Progress Agent file location

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fa87b1fc8321900a6a7c2885691d