### PR TITLE
Refactor downloader options

### DIFF
--- a/program_youtube_downloader/config.py
+++ b/program_youtube_downloader/config.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Callable, Any
+
+from .progress import on_download_progress
+
+
+@dataclass
+class DownloadOptions:
+    """Configuration for downloading YouTube content."""
+
+    save_path: Optional[Path] = None
+    download_sound_only: bool = False
+    choice_callback: Optional[Callable[[bool, Any], int]] = None
+    progress_callback: Optional[Callable[[Any, Any, int], None]] = on_download_progress

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -9,8 +9,8 @@ from .youtube_downloader import (
     program_break_time,
     clear_screen,
 )
-from .progress import on_download_progress
 from . import cli_utils
+from .config import DownloadOptions
 
 
 class YoutubeDownloader:
@@ -63,17 +63,16 @@ class YoutubeDownloader:
     def download_multiple_videos(
         self,
         url_youtube_video_links: Iterable[str],
-        download_sound_only: bool,
-        *,
-        save_path: Optional[Path] = None,
-        choice_callback: Optional[Callable[[bool, Any], int]] = None,
-        progress_callback: Optional[Callable[[Any, Any, int], None]] = on_download_progress,
+        options: DownloadOptions,
     ) -> Optional[list[str]]:
         """Download multiple YouTube videos or audio tracks."""
 
+        download_sound_only = options.download_sound_only
+        save_path = options.save_path or Path.cwd()
+        choice_callback = options.choice_callback
+        progress_callback = options.progress_callback
+
         choice_once = True
-        if save_path is None:
-            save_path = Path.cwd()
 
         url_list = list(url_youtube_video_links)
         if not url_list:

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -11,6 +11,7 @@ if '__annotations__' not in globals():
 from . import youtube_downloader
 from . import cli_utils
 from .downloader import YoutubeDownloader
+from .config import DownloadOptions
 from .progress import on_download_progress
 
 
@@ -76,12 +77,15 @@ def menu() -> None:
                     download_sound_only = False
 
                 save_path = cli_utils.demander_save_file_path()
-                yd.download_multiple_videos(
-                    url_video_send_user_list,
-                    download_sound_only,
+                options = DownloadOptions(
                     save_path=save_path,
+                    download_sound_only=download_sound_only,
                     choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
                     progress_callback=on_download_progress,
+                )
+                yd.download_multiple_videos(
+                    url_video_send_user_list,
+                    options,
                 )
             case 2 | 6:
                 youtube_video_links: list[str] = cli_utils.demander_youtube_link_file()
@@ -89,12 +93,15 @@ def menu() -> None:
                     download_sound_only = False
 
                 save_path = cli_utils.demander_save_file_path()
-                yd.download_multiple_videos(
-                    youtube_video_links,
-                    download_sound_only,
+                options = DownloadOptions(
                     save_path=save_path,
+                    download_sound_only=download_sound_only,
                     choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
                     progress_callback=on_download_progress,
+                )
+                yd.download_multiple_videos(
+                    youtube_video_links,
+                    options,
                 )
             case 3 | 7:
                 url_playlist_send_user: str = cli_utils.ask_youtube_url()
@@ -108,12 +115,15 @@ def menu() -> None:
                         download_sound_only = False
 
                     save_path = cli_utils.demander_save_file_path()
-                    yd.download_multiple_videos(
-                        link_url_playlist_youtube,
-                        download_sound_only,
+                    options = DownloadOptions(
                         save_path=save_path,
+                        download_sound_only=download_sound_only,
                         choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
                         progress_callback=on_download_progress,
+                    )
+                    yd.download_multiple_videos(
+                        link_url_playlist_youtube,
+                        options,
                     )  # type: ignore
             case 4 | 8:
                 url_channel_send_user: str = cli_utils.ask_youtube_url()
@@ -127,12 +137,15 @@ def menu() -> None:
                         download_sound_only = False
 
                     save_path = cli_utils.demander_save_file_path()
-                    yd.download_multiple_videos(
-                        link_url_channel_youtube,
-                        download_sound_only,
+                    options = DownloadOptions(
                         save_path=save_path,
+                        download_sound_only=download_sound_only,
                         choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
                         progress_callback=on_download_progress,
+                    )
+                    yd.download_multiple_videos(
+                        link_url_channel_youtube,
+                        options,
                     )  # type: ignore
 
     
@@ -181,32 +194,41 @@ def main(argv: list[str] | None = None) -> None:
 
     if command == "video":
         save_path = cli_utils.demander_save_file_path()
-        yd.download_multiple_videos(
-            args.urls,
-            args.audio,
+        options = DownloadOptions(
             save_path=save_path,
+            download_sound_only=args.audio,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
             progress_callback=on_download_progress,
+        )
+        yd.download_multiple_videos(
+            args.urls,
+            options,
         )
     elif command == "playlist":
         playlist = youtube_downloader.Playlist(args.url)
         save_path = cli_utils.demander_save_file_path()
-        yd.download_multiple_videos(
-            playlist,
-            args.audio,
+        options = DownloadOptions(
             save_path=save_path,
+            download_sound_only=args.audio,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
             progress_callback=on_download_progress,
+        )
+        yd.download_multiple_videos(
+            playlist,
+            options,
         )  # type: ignore
     elif command == "channel":
         channel = youtube_downloader.Channel(args.url)
         save_path = cli_utils.demander_save_file_path()
-        yd.download_multiple_videos(
-            channel,
-            args.audio,
+        options = DownloadOptions(
             save_path=save_path,
+            download_sound_only=args.audio,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
             progress_callback=on_download_progress,
+        )
+        yd.download_multiple_videos(
+            channel,
+            options,
         )  # type: ignore
     else:
         raise SystemExit(f"Unknown command: {command}")

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from program_youtube_downloader import downloader as downloader_module
 from program_youtube_downloader.downloader import YoutubeDownloader
+from program_youtube_downloader.config import DownloadOptions
 
 class DummyStream:
     itag = 1
@@ -51,9 +52,15 @@ def test_download_multiple_videos_custom_callbacks(monkeypatch, tmp_path: Path) 
         called['progress'] = True
 
     yd = YoutubeDownloader()
+    options = DownloadOptions(
+        save_path=tmp_path,
+        download_sound_only=False,
+        choice_callback=choice_cb,
+        progress_callback=progress_cb,
+    )
     yd.download_multiple_videos([
         "https://youtu.be/dummy"
-    ], False, save_path=tmp_path, choice_callback=choice_cb, progress_callback=progress_cb)
+    ], options)
 
     assert (tmp_path / "sample.mp4").exists()
     assert created['yt'].progress is progress_cb
@@ -77,9 +84,14 @@ def test_download_multiple_videos_instantiation_error(monkeypatch, tmp_path: Pat
         called['progress'] = True
 
     yd = YoutubeDownloader()
+    options = DownloadOptions(
+        save_path=tmp_path,
+        download_sound_only=False,
+        progress_callback=progress_cb,
+    )
     yd.download_multiple_videos([
         "https://youtu.be/fail"
-    ], False, save_path=tmp_path, progress_callback=progress_cb)
+    ], options)
 
     assert not any(tmp_path.iterdir())
     assert 'progress' not in called
@@ -103,9 +115,14 @@ def test_download_multiple_videos_no_streams(monkeypatch, tmp_path: Path) -> Non
         called['progress'] = True
 
     yd = YoutubeDownloader()
+    options = DownloadOptions(
+        save_path=tmp_path,
+        download_sound_only=False,
+        progress_callback=progress_cb,
+    )
     yd.download_multiple_videos([
         "https://youtu.be/nostreams"
-    ], False, save_path=tmp_path, progress_callback=progress_cb)
+    ], options)
 
     assert not any(tmp_path.iterdir())
     assert called == {}


### PR DESCRIPTION
## Summary
- introduce `DownloadOptions` dataclass in new `config.py`
- refactor `YoutubeDownloader.download_multiple_videos` to use options object
- update CLI and tests to pass `DownloadOptions`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843045e2d0083218cbacdb44719bb6e