### PR TITLE
Add pluggable progress handler

### DIFF
--- a/program_youtube_downloader/config.py
+++ b/program_youtube_downloader/config.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Callable, Any
 
-from .progress import on_download_progress
+from .progress import ProgressHandler, ProgressBarHandler
 
 
 @dataclass
@@ -12,4 +12,4 @@ class DownloadOptions:
     save_path: Optional[Path] = None
     download_sound_only: bool = False
     choice_callback: Optional[Callable[[bool, Any], int]] = None
-    progress_callback: Optional[Callable[[Any, Any, int], None]] = on_download_progress
+    progress_handler: Optional[ProgressHandler] = None

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -11,10 +11,14 @@ from .youtube_downloader import (
 )
 from . import cli_utils
 from .config import DownloadOptions
+from .progress import ProgressHandler, ProgressBarHandler
 
 
 class YoutubeDownloader:
     """Responsible for fetching streams and saving downloaded files."""
+
+    def __init__(self, progress_handler: ProgressHandler | None = None) -> None:
+        self.progress_handler = progress_handler or ProgressBarHandler()
 
     def streams_video(self, download_sound_only: bool, youtube_video: YouTube):
         try:
@@ -70,7 +74,7 @@ class YoutubeDownloader:
         download_sound_only = options.download_sound_only
         save_path = options.save_path or Path.cwd()
         choice_callback = options.choice_callback
-        progress_callback = options.progress_callback
+        progress_handler = options.progress_handler or self.progress_handler
 
         choice_once = True
 
@@ -82,8 +86,8 @@ class YoutubeDownloader:
         for url_video in url_list:
             try:
                 youtube_video = YouTube(url_video)
-                if progress_callback:
-                    youtube_video.register_on_progress_callback(progress_callback)
+                if progress_handler:
+                    youtube_video.register_on_progress_callback(progress_handler.on_progress)
             except KeyError as e:
                 logging.error("[ERREUR] : Problème de clé dans les données : %s", e)
                 continue

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -12,7 +12,7 @@ from . import youtube_downloader
 from . import cli_utils
 from .downloader import YoutubeDownloader
 from .config import DownloadOptions
-from .progress import on_download_progress
+
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -81,7 +81,6 @@ def menu() -> None:
                     save_path=save_path,
                     download_sound_only=download_sound_only,
                     choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                    progress_callback=on_download_progress,
                 )
                 yd.download_multiple_videos(
                     url_video_send_user_list,
@@ -97,7 +96,6 @@ def menu() -> None:
                     save_path=save_path,
                     download_sound_only=download_sound_only,
                     choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                    progress_callback=on_download_progress,
                 )
                 yd.download_multiple_videos(
                     youtube_video_links,
@@ -119,7 +117,6 @@ def menu() -> None:
                         save_path=save_path,
                         download_sound_only=download_sound_only,
                         choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                        progress_callback=on_download_progress,
                     )
                     yd.download_multiple_videos(
                         link_url_playlist_youtube,
@@ -141,7 +138,6 @@ def menu() -> None:
                         save_path=save_path,
                         download_sound_only=download_sound_only,
                         choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-                        progress_callback=on_download_progress,
                     )
                     yd.download_multiple_videos(
                         link_url_channel_youtube,
@@ -198,7 +194,6 @@ def main(argv: list[str] | None = None) -> None:
             save_path=save_path,
             download_sound_only=args.audio,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-            progress_callback=on_download_progress,
         )
         yd.download_multiple_videos(
             args.urls,
@@ -211,7 +206,6 @@ def main(argv: list[str] | None = None) -> None:
             save_path=save_path,
             download_sound_only=args.audio,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-            progress_callback=on_download_progress,
         )
         yd.download_multiple_videos(
             playlist,
@@ -224,7 +218,6 @@ def main(argv: list[str] | None = None) -> None:
             save_path=save_path,
             download_sound_only=args.audio,
             choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
-            progress_callback=on_download_progress,
         )
         yd.download_multiple_videos(
             channel,

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -1,16 +1,23 @@
 import sys
+from typing import Protocol
+
 import colorama
 from colorama import init
 
 init(autoreset=True)
 
 
-def on_download_progress(stream, chunk, bytes_remaining) -> None:
-    """Display progress percentage while downloading."""
-    total_bytes_download = stream.filesize
-    bytes_downloaded = stream.filesize - bytes_remaining
-    progress = (bytes_downloaded / total_bytes_download) * 100
-    progress_bar(progress)
+class ProgressHandler(Protocol):
+    """Interface for receiving progress events from pytube."""
+
+    def on_progress(self, stream, chunk, bytes_remaining) -> None:  # pragma: no cover - typing
+        """Handle a download progress event."""
+        raise NotImplementedError
+
+
+def on_download_progress(stream, chunk, bytes_remaining) -> None:  # pragma: no cover - legacy
+    """Backward compatible wrapper around :class:`ProgressBarHandler`."""
+    ProgressBarHandler().on_progress(stream, chunk, bytes_remaining)
 
 
 def progress_bar(
@@ -35,3 +42,13 @@ def progress_bar(
         print(colorama.Fore.RESET)
 
     sys.stdout.flush()
+
+
+class ProgressBarHandler:
+    """Default progress handler displaying a textual bar."""
+
+    def on_progress(self, stream, chunk, bytes_remaining) -> None:
+        total_bytes_download = stream.filesize
+        bytes_downloaded = stream.filesize - bytes_remaining
+        progress = (bytes_downloaded / total_bytes_download) * 100
+        progress_bar(progress)


### PR DESCRIPTION
## Summary
- define `ProgressHandler` protocol and `ProgressBarHandler` default impl
- pass handler objects through `YoutubeDownloader`
- store handler in `DownloadOptions`
- adjust CLI and tests for new abstraction

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684306063f188321a2db1a7e605be8bd