### PR TITLE
Support custom YouTube factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,10 @@ main()
 
 **Dependencies**: `pytubefix`, validation helpers and progress agent.
 
+`YoutubeDownloader` accepts an optional `youtube_cls` factory to create
+`pytubefix.YouTube` objects. Tests can supply a dummy constructor to avoid
+network access.
+
 Usage:
 ```python
 from downloader import YoutubeDownloader

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -17,8 +17,13 @@ from .progress import ProgressHandler, ProgressBarHandler
 class YoutubeDownloader:
     """Responsible for fetching streams and saving downloaded files."""
 
-    def __init__(self, progress_handler: ProgressHandler | None = None) -> None:
+    def __init__(
+        self,
+        progress_handler: ProgressHandler | None = None,
+        youtube_cls: Callable[[str], YouTube] = YouTube,
+    ) -> None:
         self.progress_handler = progress_handler or ProgressBarHandler()
+        self.youtube_cls = youtube_cls
 
     def streams_video(self, download_sound_only: bool, youtube_video: YouTube):
         try:
@@ -85,7 +90,7 @@ class YoutubeDownloader:
 
         for url_video in url_list:
             try:
-                youtube_video = YouTube(url_video)
+                youtube_video = self.youtube_cls(url_video)
                 if progress_handler:
                     youtube_video.register_on_progress_callback(progress_handler.on_progress)
             except KeyError as e:

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -43,7 +43,6 @@ def test_download_multiple_videos_custom_callbacks(monkeypatch, tmp_path: Path) 
         created['yt'] = yt
         return yt
 
-    monkeypatch.setattr(downloader_module, "YouTube", fake_constructor)
     monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
     monkeypatch.setattr(downloader_module, "program_break_time", lambda *a, **k: None)
@@ -56,7 +55,7 @@ def test_download_multiple_videos_custom_callbacks(monkeypatch, tmp_path: Path) 
         return 1
 
     progress = DummyHandler()
-    yd = YoutubeDownloader(progress_handler=progress)
+    yd = YoutubeDownloader(progress_handler=progress, youtube_cls=fake_constructor)
     options = DownloadOptions(
         save_path=tmp_path,
         download_sound_only=False,
@@ -77,13 +76,12 @@ def test_download_multiple_videos_instantiation_error(monkeypatch, tmp_path: Pat
     def fake_constructor(url: str) -> DummyYT:
         raise KeyError("boom")
 
-    monkeypatch.setattr(downloader_module, "YouTube", fake_constructor)
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
     monkeypatch.setattr(downloader_module, "program_break_time", lambda *a, **k: None)
     monkeypatch.setattr(downloader_module, "clear_screen", lambda *a, **k: None)
 
     progress = DummyHandler()
-    yd = YoutubeDownloader(progress_handler=progress)
+    yd = YoutubeDownloader(progress_handler=progress, youtube_cls=fake_constructor)
     options = DownloadOptions(
         save_path=tmp_path,
         download_sound_only=False,
@@ -102,14 +100,13 @@ def test_download_multiple_videos_no_streams(monkeypatch, tmp_path: Path) -> Non
     def fake_constructor(url: str) -> DummyYT:
         return DummyYT(url)
 
-    monkeypatch.setattr(downloader_module, "YouTube", fake_constructor)
     monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: None)
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
     monkeypatch.setattr(downloader_module, "program_break_time", lambda *a, **k: None)
     monkeypatch.setattr(downloader_module, "clear_screen", lambda *a, **k: None)
 
     progress = DummyHandler()
-    yd = YoutubeDownloader(progress_handler=progress)
+    yd = YoutubeDownloader(progress_handler=progress, youtube_cls=fake_constructor)
     options = DownloadOptions(
         save_path=tmp_path,
         download_sound_only=False,


### PR DESCRIPTION
## Summary
- inject optional factory parameter into `YoutubeDownloader`
- use the factory when creating YouTube objects
- update tests to pass dummy constructor
- document the new parameter in **AGENTS.md**

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843080b58f48321901fd12a01455356