### PR TITLE
Implement directory validation for save path

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -59,14 +59,34 @@ def afficher_menu_acceuil() -> int:
 
 
 def demander_save_file_path() -> Path:
+    """Ask for a destination directory and ensure it exists."""
+
     print()
     print()
     print_separator()
     print("*             Sauvegarde fichier                            *")
     print_separator()
-    save_path = input("Indiquez l'endroit où vous voulez stocker le fichier : \n --> ")
 
-    return Path(save_path)
+    save_path = input("Indiquez l'endroit où vous voulez stocker le fichier : \n --> ")
+    path = Path(save_path).expanduser().resolve()
+
+    if path.is_file():
+        path = path.parent
+
+    if not path.exists():
+        create = input("Le dossier n'existe pas. Voulez-vous le créer ? [y/N] : ")
+        if create.lower().startswith("y"):
+            try:
+                path.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                logging.exception("Directory creation failed")
+                print("[ERREUR] : Impossible de créer le dossier")
+                return demander_save_file_path()
+        else:
+            print("[ERREUR] : Le dossier n'existe pas")
+            return demander_save_file_path()
+
+    return path
 
 
 def ask_youtube_url() -> str:

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -33,3 +33,29 @@ def test_ask_youtube_url_invalid_then_valid(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
     url = cli_utils.ask_youtube_url()
     assert url == "https://www.youtube.com/watch?v=good"
+
+
+def test_demander_save_file_path_existing(tmp_path, monkeypatch):
+    inputs = iter([str(tmp_path)])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+    p = cli_utils.demander_save_file_path()
+    assert p == tmp_path.resolve()
+
+
+def test_demander_save_file_path_create(tmp_path, monkeypatch):
+    new_dir = tmp_path / "newdir"
+    inputs = iter([str(new_dir), "y"])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+    p = cli_utils.demander_save_file_path()
+    assert p == new_dir.resolve()
+    assert new_dir.exists()
+
+
+def test_demander_save_file_path_retry(monkeypatch, tmp_path):
+    missing = tmp_path / "missing"
+    existing = tmp_path / "exists"
+    existing.mkdir()
+    inputs = iter([str(missing), "n", str(existing)])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+    p = cli_utils.demander_save_file_path()
+    assert p == existing.resolve()


### PR DESCRIPTION
## Summary
- check save directory exists in `demander_save_file_path`
- allow optional creation of a missing directory
- return absolute save path
- test new behaviour for existing and new paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843091704508321bf4a95f77c241708