### PR TITLE
Use logging instead of print

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -25,14 +25,14 @@ def ask_numeric_value(valeur_min: int, valeur_max: int) -> int:
         try:
             v_int = int(v_str)
         except ValueError:
-            print("FAIL : Vous devez rentrer une valeur numérique.")
-            print()
+            logging.warning("FAIL : Vous devez rentrer une valeur numérique.")
+            logging.info("")
             continue
         if not (valeur_min <= v_int <= valeur_max):
-            print(
+            logging.warning(
                 f"FAIL : Vous devez rentrer un nombre (entre {valeur_min} et {valeur_max} )."
             )
-            print()
+            logging.info("")
             continue
 
         return v_int
@@ -80,10 +80,10 @@ def demander_save_file_path() -> Path:
                 path.mkdir(parents=True, exist_ok=True)
             except OSError:
                 logging.exception("Directory creation failed")
-                print("[ERREUR] : Impossible de créer le dossier")
+                logging.error("[ERREUR] : Impossible de créer le dossier")
                 return demander_save_file_path()
         else:
-            print("[ERREUR] : Le dossier n'existe pas")
+            logging.error("[ERREUR] : Le dossier n'existe pas")
             return demander_save_file_path()
 
     return path
@@ -104,8 +104,8 @@ def ask_youtube_url() -> str:
         if url.lower().startswith(BASE_YOUTUBE_URL):
             return url
 
-        print("ERREUR : Vous devez renter une URL de vidéo youtube")
-        print("le prefixe attendu est : https://www.youtube.com/")
+        logging.error("ERREUR : Vous devez renter une URL de vidéo youtube")
+        logging.error("le prefixe attendu est : https://www.youtube.com/")
 
 
 def demander_youtube_link_file() -> list[str]:
@@ -126,7 +126,7 @@ def demander_youtube_link_file() -> list[str]:
             number_links_file = len(lignes)
 
             if not number_links_file:
-                print("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
+                logging.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
                 return demander_youtube_link_file()
 
             for i in range(0, len(lignes)):
@@ -136,18 +136,18 @@ def demander_youtube_link_file() -> list[str]:
                 if url_video.lower().startswith(BASE_YOUTUBE_URL):
                     link_url_video_youtube_final.append(url_video)
                 else:
-                    print("[ERREUR] : ")
-                    print("le prefixe attendu est : https://www.youtube.com/")
-                    print(f"  le lien sur la ligne n° {compteur_ligne} ne sera pas télécharger")
-                    print("")
+                    logging.error("[ERREUR] : ")
+                    logging.error("le prefixe attendu est : https://www.youtube.com/")
+                    logging.error(f"  le lien sur la ligne n° {compteur_ligne} ne sera pas télécharger")
+                    logging.error("")
                     number_erreur += 1
 
             if number_erreur == number_links_file:
-                print("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
+                logging.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
                 return demander_youtube_link_file()
     except OSError as e:
         logging.exception("[ERREUR] : Le fichier n'est pas accessible")
-        print("[ERREUR] : Le fichier n'est pas accessible")
+        logging.error("[ERREUR] : Le fichier n'est pas accessible")
 
     return link_url_video_youtube_final
 

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -64,10 +64,10 @@ class YoutubeDownloader:
                 file_path.unlink()
         except OSError:
             logging.exception("Error during MP4 to MP3 conversion")
-            print("[WARMING] un fichier MP3 portant le même nom, déjà existant!")
+            logging.warning("[WARMING] un fichier MP3 portant le même nom, déjà existant!")
             if file_path.exists():
                 file_path.unlink()
-            print()
+            logging.info("")
 
     def download_multiple_videos(
         self,
@@ -132,43 +132,42 @@ class YoutubeDownloader:
                 else:
                     choice_user = 1
                 choice_once = False
-                print()
-                print()
+                logging.info("")
+                logging.info("")
                 cli_utils.print_separator()
-                print("*             Stream vidéo selectionnée:                    *")
+                logging.info("*             Stream vidéo selectionnée:                    *")
                 cli_utils.print_separator()
-                print(
-                    "Number of link url video youtube in file: ",
+                logging.info("Number of link url video youtube in file: %s",
                     len(url_list),
                 )
-                print()
+                logging.info("")
 
             itag = streams[choice_user - 1].itag  # type: ignore
             stream = youtube_video.streams.get_by_itag(itag)
 
-            print(f"Titre: {video_title[0:53]}")
+            logging.info("Titre: %s", video_title[0:53])
 
             current_file = save_path / stream.default_filename  # type: ignore
             if current_file.exists():
-                print("[WARMING] un fichier MP4 portant le même nom, déjà existant!")
+                logging.warning("[WARMING] un fichier MP4 portant le même nom, déjà existant!")
 
             try:
                 out_file = Path(stream.download(output_path=str(save_path)))  # type: ignore
-                print()
+                logging.info("")
             except Exception as e:  # pragma: no cover - network/io issues
                 logging.exception("Download failed")
-                print()
+                logging.info("")
                 logging.error("[ERREUR] : le téléchargement a échoué : %s", e)
-                print()
+                logging.info("")
                 continue
 
             if out_file and download_sound_only:
                 self.conversion_mp4_in_mp3(out_file)
 
-        print()
-        print("Fin du téléchargement")
+        logging.info("")
+        logging.info("Fin du téléchargement")
         cli_utils.print_separator()
-        print()
+        logging.info("")
         input("Appuyer sur ENTREE pour revenir au menu d'accueil")
         program_break_time(3, "Le menu d'accueil va revenir dans")
         clear_screen()

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -61,13 +61,13 @@ def menu() -> None:
 
         match reponse_utilisateur_pour_choix_dans_menu:
             case 9:
-                print()
-                print()
-                print("*************************************************************")
-                print("*                                                           *")
-                print("*                    Fin du programme                       *")
-                print("*                                                           *")
-                print("*************************************************************")
+                logging.info("")
+                logging.info("")
+                logging.info("*************************************************************")
+                logging.info("*                                                           *")
+                logging.info("*                    Fin du programme                       *")
+                logging.info("*                                                           *")
+                logging.info("*************************************************************")
                 break
             case 1 | 5:
                 url_video_send_user_list: list[str] = []
@@ -107,7 +107,7 @@ def menu() -> None:
                     link_url_playlist_youtube = youtube_downloader.Playlist(url_playlist_send_user)
                 except Exception as exc:
                     logging.exception("Error connecting to playlist")
-                    print("[ERREUR] : Connexion à la Playlist impossible")
+                    logging.error("[ERREUR] : Connexion à la Playlist impossible")
                 else:
                     if reponse_utilisateur_pour_choix_dans_menu == 3:
                         download_sound_only = False
@@ -128,7 +128,7 @@ def menu() -> None:
                     link_url_channel_youtube = youtube_downloader.Channel(url_channel_send_user)
                 except Exception as exc:
                     logging.exception("Error connecting to channel")
-                    print("[ERREUR] : Connexion à la chaîne Youtube impossible")
+                    logging.error("[ERREUR] : Connexion à la chaîne Youtube impossible")
                 else:
                     if reponse_utilisateur_pour_choix_dans_menu == 4:
                         download_sound_only = False


### PR DESCRIPTION
## Summary
- switch downloader status messages to use `logging`
- emit errors in CLI helpers via `logging`
- log exit message and connection failures in main

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684309edb68883219c97e963bd87e113