### PR TITLE
Refactor download prompts

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -10,6 +10,7 @@ from .constants import (
     CHOICE_MENU_ACCUEIL,
     BASE_YOUTUBE_URL,
 )
+from .youtube_downloader import program_break_time, clear_screen
 
 
 def print_separator() -> None:
@@ -193,3 +194,18 @@ def demander_choice_resolution_vidéo_or_bitrate_audio(
     print_separator()
     v_int = ask_numeric_value(1, valeur_choix_maximale)
     return v_int
+
+
+def print_end_download_message() -> None:
+    """Display a message indicating the downloads are finished."""
+    logging.info("")
+    logging.info("Fin du téléchargement")
+    print_separator()
+    logging.info("")
+
+
+def pause_return_to_menu() -> None:
+    """Pause execution until the user presses ENTER and clear the screen."""
+    input("Appuyer sur ENTREE pour revenir au menu d'accueil")
+    program_break_time(3, "Le menu d'accueil va revenir dans")
+    clear_screen()

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -5,10 +5,6 @@ import logging
 
 from pytubefix import YouTube
 
-from .youtube_downloader import (
-    program_break_time,
-    clear_screen,
-)
 from . import cli_utils
 from .config import DownloadOptions
 from .progress import ProgressHandler, ProgressBarHandler
@@ -168,13 +164,8 @@ class YoutubeDownloader:
             if out_file and download_sound_only:
                 self.conversion_mp4_in_mp3(out_file)
 
-        logging.info("")
-        logging.info("Fin du téléchargement")
-        cli_utils.print_separator()
-        logging.info("")
-        input("Appuyer sur ENTREE pour revenir au menu d'accueil")
-        program_break_time(3, "Le menu d'accueil va revenir dans")
-        clear_screen()
+        cli_utils.print_end_download_message()
+        cli_utils.pause_return_to_menu()
 
         return None
 

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from program_youtube_downloader import downloader as downloader_module
+from program_youtube_downloader import cli_utils
 from program_youtube_downloader.downloader import YoutubeDownloader
 from program_youtube_downloader.config import DownloadOptions
 
@@ -45,8 +46,8 @@ def test_download_multiple_videos_custom_callbacks(monkeypatch, tmp_path: Path) 
 
     monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
-    monkeypatch.setattr(downloader_module, "program_break_time", lambda *a, **k: None)
-    monkeypatch.setattr(downloader_module, "clear_screen", lambda *a, **k: None)
+    monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
+    monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
 
     called = {}
 
@@ -77,8 +78,8 @@ def test_download_multiple_videos_instantiation_error(monkeypatch, tmp_path: Pat
         raise KeyError("boom")
 
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
-    monkeypatch.setattr(downloader_module, "program_break_time", lambda *a, **k: None)
-    monkeypatch.setattr(downloader_module, "clear_screen", lambda *a, **k: None)
+    monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
+    monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
 
     progress = DummyHandler()
     yd = YoutubeDownloader(progress_handler=progress, youtube_cls=fake_constructor)
@@ -102,8 +103,8 @@ def test_download_multiple_videos_no_streams(monkeypatch, tmp_path: Path) -> Non
 
     monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: None)
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
-    monkeypatch.setattr(downloader_module, "program_break_time", lambda *a, **k: None)
-    monkeypatch.setattr(downloader_module, "clear_screen", lambda *a, **k: None)
+    monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
+    monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
 
     progress = DummyHandler()
     yd = YoutubeDownloader(progress_handler=progress, youtube_cls=fake_constructor)


### PR DESCRIPTION
## Summary
- centralize end-of-download message helpers in `cli_utils`
- use the new helpers in `download_multiple_videos`
- update callback tests for new helper functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430d7fc3088321baed74c7b045a87a