### PR TITLE
Add YouTube URL validator

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -11,6 +11,7 @@ from .constants import (
     BASE_YOUTUBE_URL,
 )
 from .youtube_downloader import program_break_time, clear_screen
+from .validators import validate_youtube_url
 
 
 def print_separator() -> None:
@@ -104,7 +105,7 @@ def ask_youtube_url() -> str:
         url = url.replace(
             "https://www.youtube.com/@", "https://www.youtube.com/c/"
         )
-        if url.lower().startswith(BASE_YOUTUBE_URL):
+        if validate_youtube_url(url):
             return url
 
         logging.error("ERREUR : Vous devez renter une URL de vidéo youtube")
@@ -135,10 +136,10 @@ def demander_youtube_link_file() -> list[str]:
                 return demander_youtube_link_file()
 
             for i in range(0, len(lignes)):
-                url_video = lignes[i]
+                url_video = lignes[i].strip()
                 compteur_ligne += 1
 
-                if url_video.lower().startswith(BASE_YOUTUBE_URL):
+                if validate_youtube_url(url_video):
                     link_url_video_youtube_final.append(url_video)
                 else:
                     logging.error("[ERREUR] : ")

--- a/program_youtube_downloader/validators.py
+++ b/program_youtube_downloader/validators.py
@@ -1,0 +1,19 @@
+from urllib.parse import urlparse
+
+
+def validate_youtube_url(url: str) -> bool:
+    """Return True if ``url`` appears to be a valid YouTube URL."""
+    if not url:
+        return False
+    url = url.strip()
+
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return False
+    host = parsed.netloc.lower()
+    if host == "youtu.be":
+        return True
+    if host.endswith("youtube.com"):
+        return True
+    return False
+

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -59,3 +59,17 @@ def test_demander_save_file_path_retry(monkeypatch, tmp_path):
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
     p = cli_utils.demander_save_file_path()
     assert p == existing.resolve()
+
+
+def test_demander_youtube_link_file(monkeypatch, tmp_path):
+    links_file = tmp_path / "links.txt"
+    links_file.write_text(
+        "https://www.youtube.com/watch?v=ok\ninvalid\nhttps://youtu.be/abc\n"
+    )
+    inputs = iter([str(links_file)])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+    links = cli_utils.demander_youtube_link_file()
+    assert links == [
+        "https://www.youtube.com/watch?v=ok",
+        "https://youtu.be/abc",
+    ]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,13 @@
+from program_youtube_downloader.validators import validate_youtube_url
+
+
+def test_validate_youtube_url_valid() -> None:
+    assert validate_youtube_url("https://www.youtube.com/watch?v=ok")
+    assert validate_youtube_url("https://youtube.com/watch?v=ok")
+    assert validate_youtube_url("https://youtu.be/abc")
+
+
+def test_validate_youtube_url_invalid() -> None:
+    assert not validate_youtube_url("http://example.com")
+    assert not validate_youtube_url("notaurl")
+    assert not validate_youtube_url("ftp://youtu.be/id")


### PR DESCRIPTION
## Summary
- add `validators.validate_youtube_url`
- use validator in CLI helpers
- test URL validator and updated file reading logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430e94bce88321bfd4efa5303d607f