### PR TITLE
Add environment setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ download videos, playlists or channels, or to extract audio only.
   - `colorama` (affichage en couleur)
   - et les paquets utilisés pour l’emballage avec `pyinstaller`
 
+Pour automatiser la création de `.venv` et l'installation des dépendances,
+vous pouvez lancer :
+
+```bash
+scripts/setup_env.sh
+```
+
 Installez-les avec :
 
 ```bash

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+    python -m venv .venv
+fi
+
+# Activate virtual environment
+source .venv/bin/activate
+
+# Install dependencies
+pip install -r requirements.txt
+
+echo "Virtual environment ready."
+


### PR DESCRIPTION
## Summary
- add a helper script in `scripts/` to create `.venv` and install dependencies
- document this script in the prerequisites section of the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843134bf2108321bb3db767d251b2d4