### PR TITLE
Switch to module-level logging

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 import logging
+
+logger = logging.getLogger(__name__)
 from typing import Iterable, Any
 
 from .constants import (
@@ -28,14 +30,14 @@ def ask_numeric_value(valeur_min: int, valeur_max: int) -> int:
         try:
             v_int = int(v_str)
         except ValueError:
-            logging.warning("FAIL : Vous devez rentrer une valeur numérique.")
-            logging.info("")
+            logger.warning("FAIL : Vous devez rentrer une valeur numérique.")
+            logger.info("")
             continue
         if not (valeur_min <= v_int <= valeur_max):
-            logging.warning(
+            logger.warning(
                 f"FAIL : Vous devez rentrer un nombre (entre {valeur_min} et {valeur_max} )."
             )
-            logging.info("")
+            logger.info("")
             continue
 
         return v_int
@@ -83,11 +85,11 @@ def demander_save_file_path() -> Path:
             try:
                 path.mkdir(parents=True, exist_ok=True)
             except OSError:
-                logging.exception("Directory creation failed")
-                logging.error("[ERREUR] : Impossible de créer le dossier")
+                logger.exception("Directory creation failed")
+                logger.error("[ERREUR] : Impossible de créer le dossier")
                 return demander_save_file_path()
         else:
-            logging.error("[ERREUR] : Le dossier n'existe pas")
+            logger.error("[ERREUR] : Le dossier n'existe pas")
             return demander_save_file_path()
 
     return path
@@ -108,8 +110,8 @@ def ask_youtube_url() -> str:
         if validate_youtube_url(url):
             return url
 
-        logging.error("ERREUR : Vous devez renter une URL de vidéo youtube")
-        logging.error("le prefixe attendu est : https://www.youtube.com/")
+        logger.error("ERREUR : Vous devez renter une URL de vidéo youtube")
+        logger.error("le prefixe attendu est : https://www.youtube.com/")
 
 
 def demander_youtube_link_file() -> list[str]:
@@ -132,7 +134,7 @@ def demander_youtube_link_file() -> list[str]:
             number_links_file = len(lignes)
 
             if not number_links_file:
-                logging.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
+                logger.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
                 return demander_youtube_link_file()
 
             for i in range(0, len(lignes)):
@@ -142,18 +144,18 @@ def demander_youtube_link_file() -> list[str]:
                 if validate_youtube_url(url_video):
                     link_url_video_youtube_final.append(url_video)
                 else:
-                    logging.error("[ERREUR] : ")
-                    logging.error("le prefixe attendu est : https://www.youtube.com/")
-                    logging.error(f"  le lien sur la ligne n° {compteur_ligne} ne sera pas télécharger")
-                    logging.error("")
+                    logger.error("[ERREUR] : ")
+                    logger.error("le prefixe attendu est : https://www.youtube.com/")
+                    logger.error(f"  le lien sur la ligne n° {compteur_ligne} ne sera pas télécharger")
+                    logger.error("")
                     number_erreur += 1
 
             if number_erreur == number_links_file:
-                logging.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
+                logger.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
                 return demander_youtube_link_file()
     except OSError as e:
-        logging.exception("[ERREUR] : Le fichier n'est pas accessible")
-        logging.error("[ERREUR] : Le fichier n'est pas accessible")
+        logger.exception("[ERREUR] : Le fichier n'est pas accessible")
+        logger.error("[ERREUR] : Le fichier n'est pas accessible")
 
     return link_url_video_youtube_final
 
@@ -199,10 +201,10 @@ def demander_choice_resolution_vidéo_or_bitrate_audio(
 
 def print_end_download_message() -> None:
     """Display a message indicating the downloads are finished."""
-    logging.info("")
-    logging.info("Fin du téléchargement")
+    logger.info("")
+    logger.info("Fin du téléchargement")
     print_separator()
-    logging.info("")
+    logger.info("")
 
 
 def pause_return_to_menu() -> None:

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -3,6 +3,8 @@ from pathlib import Path
 from typing import Optional, Union, Iterable, Callable, Any
 import logging
 
+logger = logging.getLogger(__name__)
+
 from pytubefix import YouTube
 
 from . import cli_utils
@@ -40,15 +42,15 @@ class YoutubeDownloader:
                 )
             return streams
         except HTTPError as e:
-            logging.error(
+            logger.error(
                 "[ERREUR] : Impossible d'accéder aux flux pour la vidéo. Code HTTP : %s, Message : %s",
                 e.code,
                 e.reason,
             )
             return None
         except Exception as e:  # pragma: no cover - defensive
-            logging.exception("Unexpected error while retrieving streams")
-            logging.error(
+            logger.exception("Unexpected error while retrieving streams")
+            logger.error(
                 "[ERREUR] : Une erreur inattendue s'est produite lors de la récupération des flux : %s",
                 e,
             )
@@ -63,11 +65,11 @@ class YoutubeDownloader:
             if file_path.exists():
                 file_path.unlink()
         except OSError:
-            logging.exception("Error during MP4 to MP3 conversion")
-            logging.warning("[WARMING] un fichier MP3 portant le même nom, déjà existant!")
+            logger.exception("Error during MP4 to MP3 conversion")
+            logger.warning("[WARMING] un fichier MP3 portant le même nom, déjà existant!")
             if file_path.exists():
                 file_path.unlink()
-            logging.info("")
+            logger.info("")
 
     def download_multiple_videos(
         self,
@@ -85,7 +87,7 @@ class YoutubeDownloader:
 
         url_list = list(url_youtube_video_links)
         if not url_list:
-            logging.error("[ERREUR] : il y a aucune vidéo à télécharger")
+            logger.error("[ERREUR] : il y a aucune vidéo à télécharger")
             return url_list
 
         for url_video in url_list:
@@ -94,16 +96,16 @@ class YoutubeDownloader:
                 if progress_handler:
                     youtube_video.register_on_progress_callback(progress_handler.on_progress)
             except KeyError as e:
-                logging.error("[ERREUR] : Problème de clé dans les données : %s", e)
+                logger.error("[ERREUR] : Problème de clé dans les données : %s", e)
                 continue
             except Exception as e:  # pragma: no cover - defensive
-                logging.exception("Unexpected error while connecting to video")
-                logging.error("[ERREUR] : Connexion à la vidéo impossible : %s", e)
+                logger.exception("Unexpected error while connecting to video")
+                logger.error("[ERREUR] : Connexion à la vidéo impossible : %s", e)
                 continue
 
             streams = self.streams_video(download_sound_only, youtube_video)
             if not streams:
-                logging.error(
+                logger.error(
                     "[ERREUR] : Les flux pour la vidéo (%s) n'ont pas pu être récupérés.",
                     url_video,
                 )
@@ -112,15 +114,15 @@ class YoutubeDownloader:
             try:
                 video_title = youtube_video.title
             except KeyError as e:
-                logging.error(
+                logger.error(
                     "[ERREUR] : Impossible d'accéder au titre de la vidéo %s. Détail : %s",
                     url_video,
                     e,
                 )
                 continue
             except Exception as e:  # pragma: no cover - defensive
-                logging.exception("Unexpected error while accessing video title")
-                logging.error(
+                logger.exception("Unexpected error while accessing video title")
+                logger.error(
                     "[ERREUR] : Une erreur inattendue s'est produite lors de l'accès au titre : %s",
                     e,
                 )
@@ -132,33 +134,33 @@ class YoutubeDownloader:
                 else:
                     choice_user = 1
                 choice_once = False
-                logging.info("")
-                logging.info("")
+                logger.info("")
+                logger.info("")
                 cli_utils.print_separator()
-                logging.info("*             Stream vidéo selectionnée:                    *")
+                logger.info("*             Stream vidéo selectionnée:                    *")
                 cli_utils.print_separator()
-                logging.info("Number of link url video youtube in file: %s",
+                logger.info("Number of link url video youtube in file: %s",
                     len(url_list),
                 )
-                logging.info("")
+                logger.info("")
 
             itag = streams[choice_user - 1].itag  # type: ignore
             stream = youtube_video.streams.get_by_itag(itag)
 
-            logging.info("Titre: %s", video_title[0:53])
+            logger.info("Titre: %s", video_title[0:53])
 
             current_file = save_path / stream.default_filename  # type: ignore
             if current_file.exists():
-                logging.warning("[WARMING] un fichier MP4 portant le même nom, déjà existant!")
+                logger.warning("[WARMING] un fichier MP4 portant le même nom, déjà existant!")
 
             try:
                 out_file = Path(stream.download(output_path=str(save_path)))  # type: ignore
-                logging.info("")
+                logger.info("")
             except Exception as e:  # pragma: no cover - network/io issues
-                logging.exception("Download failed")
-                logging.info("")
-                logging.error("[ERREUR] : le téléchargement a échoué : %s", e)
-                logging.info("")
+                logger.exception("Download failed")
+                logger.info("")
+                logger.error("[ERREUR] : le téléchargement a échoué : %s", e)
+                logger.info("")
                 continue
 
             if out_file and download_sound_only:

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -3,6 +3,8 @@
 import sys
 import argparse
 import logging
+
+logger = logging.getLogger(__name__)
 import os
 
 if '__annotations__' not in globals():
@@ -72,13 +74,13 @@ def menu() -> None:  # pragma: no cover
 
         match choix:
             case MenuOption.QUIT:
-                logging.info("")
-                logging.info("")
-                logging.info("*************************************************************")
-                logging.info("*                                                           *")
-                logging.info("*                    Fin du programme                       *")
-                logging.info("*                                                           *")
-                logging.info("*************************************************************")
+                logger.info("")
+                logger.info("")
+                logger.info("*************************************************************")
+                logger.info("*                                                           *")
+                logger.info("*                    Fin du programme                       *")
+                logger.info("*                                                           *")
+                logger.info("*************************************************************")
                 break
             case MenuOption.VIDEO | MenuOption.VIDEO_AUDIO_ONLY:
                 url_video_send_user_list: list[str] = []
@@ -107,8 +109,8 @@ def menu() -> None:  # pragma: no cover
                 try:
                     link_url_playlist_youtube = youtube_downloader.Playlist(url_playlist_send_user)
                 except Exception as exc:
-                    logging.exception("Error connecting to playlist")
-                    logging.error("[ERREUR] : Connexion à la Playlist impossible")
+                    logger.exception("Error connecting to playlist")
+                    logger.error("[ERREUR] : Connexion à la Playlist impossible")
                 else:
                     if choix is MenuOption.PLAYLIST_VIDEO:
                         download_sound_only = False
@@ -123,8 +125,8 @@ def menu() -> None:  # pragma: no cover
                 try:
                     link_url_channel_youtube = youtube_downloader.Channel(url_channel_send_user)
                 except Exception as exc:
-                    logging.exception("Error connecting to channel")
-                    logging.error("[ERREUR] : Connexion à la chaîne Youtube impossible")
+                    logger.exception("Error connecting to channel")
+                    logger.error("[ERREUR] : Connexion à la chaîne Youtube impossible")
                 else:
                     if choix is MenuOption.CHANNEL_VIDEOS:
                         download_sound_only = False

--- a/program_youtube_downloader/youtube_downloader.py
+++ b/program_youtube_downloader/youtube_downloader.py
@@ -9,6 +9,8 @@ import subprocess
 from pathlib import Path
 import logging
 
+logger = logging.getLogger(__name__)
+
 logging.basicConfig(level=logging.ERROR)
 
 


### PR DESCRIPTION
## Summary
- instantiate a `logger` with `logging.getLogger(__name__)` in runtime modules
- replace direct `logging.*` calls with `logger.*`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447a1321f08321b8ae428042a19315