### PR TITLE
Add custom exceptions with retry handling

### DIFF
--- a/program_youtube_downloader/__init__.py
+++ b/program_youtube_downloader/__init__.py
@@ -1,0 +1,4 @@
+"""Public exports for program_youtube_downloader."""
+from .exceptions import DownloadError, ValidationError
+
+__all__ = ["DownloadError", "ValidationError"]

--- a/program_youtube_downloader/exceptions.py
+++ b/program_youtube_downloader/exceptions.py
@@ -1,0 +1,7 @@
+class DownloadError(Exception):
+    """Raised when a download fails after several retries."""
+
+
+class ValidationError(Exception):
+    """Raised when user input validation repeatedly fails."""
+

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,4 +1,7 @@
+import pytest
+
 from program_youtube_downloader import cli_utils
+from program_youtube_downloader.exceptions import ValidationError
 
 
 def test_ask_numeric_value_retries(monkeypatch):
@@ -73,3 +76,17 @@ def test_demander_youtube_link_file(monkeypatch, tmp_path):
         "https://www.youtube.com/watch?v=ok",
         "https://youtu.be/abc",
     ]
+
+
+def test_ask_numeric_value_validation_error(monkeypatch):
+    inputs = iter(["x", "y", "z"])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+    with pytest.raises(ValidationError):
+        cli_utils.ask_numeric_value(1, 2)
+
+
+def test_ask_youtube_url_validation_error(monkeypatch):
+    inputs = iter(["bad", "nope", "still"])
+    monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
+    with pytest.raises(ValidationError):
+        cli_utils.ask_youtube_url()

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -96,10 +96,11 @@ def test_demander_youtube_link_file_all_invalid(monkeypatch, tmp_path):
 
 def test_demander_youtube_link_file_oserror(monkeypatch, tmp_path):
     bad = tmp_path / "bad.txt"
-    inputs = iter([str(bad)])
+    inputs = iter([str(bad), str(bad), str(bad)])
     monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
     monkeypatch.setattr(Path, "open", lambda self, *a, **k: (_ for _ in ()).throw(OSError()))
-    assert cli_utils.demander_youtube_link_file() == []
+    with pytest.raises(cli_utils.ValidationError):
+        cli_utils.demander_youtube_link_file()
 
 
 def test_print_end_download_message(caplog):


### PR DESCRIPTION
## Summary
- introduce `DownloadError` and `ValidationError`
- raise these new exceptions from CLI utilities and downloader
- export exceptions via package `__init__`
- extend tests for new failure behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447b82e97c8321bdc80a7ea59a2d52