### PR TITLE
Add --output-dir option for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,15 @@ activer un niveau plus verbeux de deux manières&nbsp;:
    pas sur la variable d'environnement&nbsp;:
 
     ```bash
-    program-youtube-downloader --log-level INFO video https://youtu.be/example
-    ```
+program-youtube-downloader --log-level INFO video https://youtu.be/example
+```
+
+Vous pouvez également passer le dossier de destination directement avec
+`--output-dir` pour les sous-commandes `video`, `playlist` et `channel` :
+
+```bash
+program-youtube-downloader video https://youtu.be/example --output-dir /chemin/de/sortie
+```
 
 ## Tests
 

--- a/tests/test_cli_parse.py
+++ b/tests/test_cli_parse.py
@@ -1,4 +1,5 @@
 from program_youtube_downloader.main import parse_args
+from pathlib import Path
 
 
 def test_parse_video_audio_flag() -> None:
@@ -39,4 +40,15 @@ def test_parse_log_level_env(monkeypatch) -> None:
     monkeypatch.setenv("PYDL_LOG_LEVEL", "INFO")
     args = parse_args(["video", "https://youtu.be/x"])
     assert args.log_level == "INFO"
+
+
+def test_parse_video_output_dir() -> None:
+    args = parse_args(["video", "https://youtu.be/x", "--output-dir", "dest"])
+    assert args.output_dir == Path("dest")
+
+
+def test_parse_playlist_output_dir() -> None:
+    url = "https://youtube.com/playlist?list=123"
+    args = parse_args(["playlist", url, "--output-dir", "/tmp/out"])
+    assert args.output_dir == Path("/tmp/out")
 


### PR DESCRIPTION
## Summary
- allow video, playlist and channel to use a `--output-dir` argument
- skip interactive path prompt when this option is provided
- document the new feature in README
- test parsing of `--output-dir`

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68447f56da8c832187c277ceec642e63