### PR TITLE
Refactor menu handlers

### DIFF
--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -92,86 +92,89 @@ def create_download_options(audio_only: bool, output_dir: Path | None = None) ->
     )
 
 
+def handle_quit_option() -> None:
+    """Display the exit banner."""
+    logger.info("")
+    logger.info("")
+    logger.info("******************************************************")
+    logger.info("*                                                    *")
+    logger.info("*                    Fin du programme                *")
+    logger.info("*                                                    *")
+    logger.info("******************************************************")
+
+
+def handle_video_option(yd: YoutubeDownloader, audio_only: bool) -> None:
+    """Download a single video or its audio track."""
+    url = cli_utils.ask_youtube_url()
+    options = create_download_options(audio_only)
+    yd.download_multiple_videos([url], options)
+
+
+def handle_videos_option(yd: YoutubeDownloader, audio_only: bool) -> None:
+    """Download multiple videos or their audio tracks from a file."""
+    urls = cli_utils.demander_youtube_link_file()
+    options = create_download_options(audio_only)
+    yd.download_multiple_videos(urls, options)
+
+
+def handle_playlist_option(yd: YoutubeDownloader, audio_only: bool) -> None:
+    """Download an entire playlist."""
+    url = cli_utils.ask_youtube_url()
+    try:
+        playlist = youtube_downloader.Playlist(url)
+    except Exception:
+        logger.exception("Error connecting to playlist")
+        logger.error("[ERREUR] : Connexion à la Playlist impossible")
+        return
+    options = create_download_options(audio_only)
+    yd.download_multiple_videos(playlist, options)  # type: ignore
+
+
+def handle_channel_option(yd: YoutubeDownloader, audio_only: bool) -> None:
+    """Download all videos from a channel."""
+    url = cli_utils.ask_youtube_url()
+    try:
+        channel = youtube_downloader.Channel(url)
+    except Exception:
+        logger.exception("Error connecting to channel")
+        logger.error("[ERREUR] : Connexion à la chaîne Youtube impossible")
+        return
+    options = create_download_options(audio_only)
+    yd.download_multiple_videos(channel, options)  # type: ignore
+
+
 def menu() -> None:  # pragma: no cover
     """Interactively ask the user what to download and start the process."""
 
     # --------------------------------------------------------------------------
     # ------------------------------- PROGRAMME PRINCIPAL ----------------------
     # --------------------------------------------------------------------------
-
     yd = YoutubeDownloader()
 
     while True:
         choix_max_menu_accueil = cli_utils.afficher_menu_acceuil()
-        choix = MenuOption(
-            cli_utils.ask_numeric_value(1, choix_max_menu_accueil)
-        )
-        download_sound_only = True
+        choix = MenuOption(cli_utils.ask_numeric_value(1, choix_max_menu_accueil))
 
         match choix:
             case MenuOption.QUIT:
-                logger.info("")
-                logger.info("")
-                logger.info("*************************************************************")
-                logger.info("*                                                           *")
-                logger.info("*                    Fin du programme                       *")
-                logger.info("*                                                           *")
-                logger.info("*************************************************************")
+                handle_quit_option()
                 break
-            case MenuOption.VIDEO | MenuOption.VIDEO_AUDIO_ONLY:
-                url_video_send_user_list: list[str] = []
-                url_video_send_user: str = cli_utils.ask_youtube_url()
-                url_video_send_user_list.append(url_video_send_user)
-                if choix is MenuOption.VIDEO:
-                    download_sound_only = False
-
-                options = create_download_options(download_sound_only)
-                yd.download_multiple_videos(
-                    url_video_send_user_list,
-                    options,
-                )
-            case MenuOption.VIDEOS | MenuOption.VIDEOS_AUDIO_ONLY:
-                youtube_video_links: list[str] = cli_utils.demander_youtube_link_file()
-                if choix is MenuOption.VIDEOS:
-                    download_sound_only = False
-
-                options = create_download_options(download_sound_only)
-                yd.download_multiple_videos(
-                    youtube_video_links,
-                    options,
-                )
-            case MenuOption.PLAYLIST_VIDEO | MenuOption.PLAYLIST_AUDIO_ONLY:
-                url_playlist_send_user: str = cli_utils.ask_youtube_url()
-                try:
-                    link_url_playlist_youtube = youtube_downloader.Playlist(url_playlist_send_user)
-                except Exception as exc:
-                    logger.exception("Error connecting to playlist")
-                    logger.error("[ERREUR] : Connexion à la Playlist impossible")
-                else:
-                    if choix is MenuOption.PLAYLIST_VIDEO:
-                        download_sound_only = False
-
-                    options = create_download_options(download_sound_only)
-                    yd.download_multiple_videos(
-                        link_url_playlist_youtube,
-                        options,
-                    )  # type: ignore
-            case MenuOption.CHANNEL_VIDEOS | MenuOption.CHANNEL_AUDIO_ONLY:
-                url_channel_send_user: str = cli_utils.ask_youtube_url()
-                try:
-                    link_url_channel_youtube = youtube_downloader.Channel(url_channel_send_user)
-                except Exception as exc:
-                    logger.exception("Error connecting to channel")
-                    logger.error("[ERREUR] : Connexion à la chaîne Youtube impossible")
-                else:
-                    if choix is MenuOption.CHANNEL_VIDEOS:
-                        download_sound_only = False
-
-                    options = create_download_options(download_sound_only)
-                    yd.download_multiple_videos(
-                        link_url_channel_youtube,
-                        options,
-                    )  # type: ignore
+            case MenuOption.VIDEO:
+                handle_video_option(yd, False)
+            case MenuOption.VIDEO_AUDIO_ONLY:
+                handle_video_option(yd, True)
+            case MenuOption.VIDEOS:
+                handle_videos_option(yd, False)
+            case MenuOption.VIDEOS_AUDIO_ONLY:
+                handle_videos_option(yd, True)
+            case MenuOption.PLAYLIST_VIDEO:
+                handle_playlist_option(yd, False)
+            case MenuOption.PLAYLIST_AUDIO_ONLY:
+                handle_playlist_option(yd, True)
+            case MenuOption.CHANNEL_VIDEOS:
+                handle_channel_option(yd, False)
+            case MenuOption.CHANNEL_AUDIO_ONLY:
+                handle_channel_option(yd, True)
 
     
 # import sys

--- a/tests/test_menu_handlers.py
+++ b/tests/test_menu_handlers.py
@@ -1,0 +1,49 @@
+import logging
+from pathlib import Path
+
+import program_youtube_downloader.main as main_module
+from program_youtube_downloader.config import DownloadOptions
+
+
+class DummyDownloader:
+    def __init__(self):
+        self.called = None
+
+    def download_multiple_videos(self, urls, options):
+        self.called = (list(urls), options)
+
+
+def test_handle_video_option(monkeypatch, tmp_path):
+    dd = DummyDownloader()
+    monkeypatch.setattr(main_module.cli_utils, "ask_youtube_url", lambda: "https://youtu.be/x")
+    monkeypatch.setattr(main_module, "create_download_options", lambda ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
+    main_module.handle_video_option(dd, True)
+    assert dd.called[0] == ["https://youtu.be/x"]
+    assert dd.called[1].download_sound_only is True
+
+
+def test_handle_videos_option(monkeypatch, tmp_path):
+    dd = DummyDownloader()
+    monkeypatch.setattr(main_module.cli_utils, "demander_youtube_link_file", lambda: ["https://youtu.be/a", "https://youtu.be/b"])
+    monkeypatch.setattr(main_module, "create_download_options", lambda ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
+    main_module.handle_videos_option(dd, False)
+    assert dd.called[0] == ["https://youtu.be/a", "https://youtu.be/b"]
+    assert dd.called[1].download_sound_only is False
+
+
+def test_handle_playlist_option(monkeypatch, tmp_path):
+    dd = DummyDownloader()
+    monkeypatch.setattr(main_module.cli_utils, "ask_youtube_url", lambda: "https://youtube.com/playlist")
+    monkeypatch.setattr(main_module.youtube_downloader, "Playlist", lambda url: ["v1"])
+    monkeypatch.setattr(main_module, "create_download_options", lambda ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
+    main_module.handle_playlist_option(dd, True)
+    assert dd.called[0] == ["v1"]
+    assert dd.called[1].download_sound_only is True
+
+
+def test_handle_channel_option_error(monkeypatch):
+    dd = DummyDownloader()
+    monkeypatch.setattr(main_module.cli_utils, "ask_youtube_url", lambda: "https://youtube.com/channel")
+    monkeypatch.setattr(main_module.youtube_downloader, "Channel", lambda url: (_ for _ in ()).throw(ValueError()))
+    main_module.handle_channel_option(dd, False)
+    assert dd.called is None


### PR DESCRIPTION
## Summary
- refactor the interactive menu in `main.py` by extracting handling code into dedicated functions
- call these helpers from `menu()`
- add unit tests for the new menu handler functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684498bf714c8321b2055b245db4509c