### PR TITLE
Fix duplicate streams logic

### DIFF
--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -116,25 +116,18 @@ class YoutubeDownloader:
         """Return the available streams for ``youtube_video``.
 
         Args:
-            download_sound_only: If ``True`` only audio streams are returned.
+            download_sound_only: Ignored, kept for backward compatibility.
             youtube_video: An instance of :class:`pytubefix.YouTube`.
 
         Returns:
             The list of available streams or ``None`` if retrieval failed.
         """
         try:
-            if download_sound_only:
-                streams = (
-                    youtube_video.streams.filter(progressive=True, file_extension="mp4")
-                    .order_by("resolution")
-                    .desc()
-                )
-            else:
-                streams = (
-                    youtube_video.streams.filter(progressive=True, file_extension="mp4")
-                    .order_by("resolution")
-                    .desc()
-                )
+            streams = (
+                youtube_video.streams.filter(progressive=True, file_extension="mp4")
+                .order_by("resolution")
+                .desc()
+            )
             return streams
         except HTTPError as e:
             logger.error(

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -167,7 +167,8 @@ def test_streams_video_success(monkeypatch):
 
     yt.streams = Chain()
     yd = YoutubeDownloader()
-    assert yd.streams_video(True, yt) is result
+    # download_sound_only parameter is ignored but kept for API compatibility
+    assert yd.streams_video(False, yt) is result
 
 
 def test_conversion_mp4_in_mp3_rename_error(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- simplify `streams_video` implementation
- adjust `test_streams_video_success` since the flag no longer matters

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449ae04d788321bff10e21a282c3ce