### PR TITLE
Affichage du compte à rebours

### DIFF
--- a/program_youtube_downloader/youtube_downloader.py
+++ b/program_youtube_downloader/youtube_downloader.py
@@ -47,10 +47,14 @@ def program_break_time(memorization_time: int, affichage_text: str) -> None:
         affichage_text: Message displayed before the countdown number.
     """
     duree_restante_avant_lancement = memorization_time
-    print(f"{affichage_text} {memorization_time} secondes ", end="", flush=True)
-    for i in range(memorization_time):
+    print(
+        f"{affichage_text} {memorization_time} secondes ",
+        end="",
+        flush=True,
+    )
+    while duree_restante_avant_lancement > 0:
         time.sleep(1)
-        print(".", end="", flush=True)
+        print(f"{duree_restante_avant_lancement} ", end="", flush=True)
         duree_restante_avant_lancement -= 1
 
 

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -110,12 +110,12 @@ def test_progressbarhandler_on_progress(capsys):
 # ---------------------------------------------------------------------------
 
 def test_program_break_time(monkeypatch, capsys):
-    """Countdown should print dots without sleeping when patched."""
+    """Countdown should print remaining seconds without sleeping when patched."""
     monkeypatch.setattr(youtube_downloader.time, "sleep", lambda x: None)
     youtube_downloader.program_break_time(3, "Wait")
     out = capsys.readouterr().out
-    assert out.count(".") == 3
     assert "Wait 3 secondes" in out
+    assert "3 2 1" in out
 
 
 def test_clear_screen(monkeypatch):


### PR DESCRIPTION
## Notes
- utilise la variable `duree_restante_avant_lancement` pour montrer le temps restant dans `program_break_time`
- met à jour le test associé

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68449e6e2d948321a3a54324605292a7