### PR TITLE
Add YouTubeVideo protocol

### DIFF
--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -7,6 +7,8 @@ logger = logging.getLogger(__name__)
 
 from pytubefix import YouTube
 
+from .types import YouTubeVideo
+
 from .exceptions import DownloadError
 
 from . import cli_utils
@@ -20,15 +22,16 @@ class YoutubeDownloader:
     def __init__(
         self,
         progress_handler: ProgressHandler | None = None,
-        youtube_cls: Callable[[str], YouTube] = YouTube,
+        youtube_cls: Callable[[str], YouTubeVideo] = YouTube,
     ) -> None:
         """Create the downloader.
 
         Args:
             progress_handler: Handler receiving progress events from
                 ``pytubefix``. If ``None`` a :class:`ProgressBarHandler` is used.
-            youtube_cls: Factory used to create :class:`pytubefix.YouTube`
-                objects. Tests may provide a mock implementation.
+            youtube_cls: Factory used to create objects following the
+                :class:`~program_youtube_downloader.types.YouTubeVideo` protocol.
+                Tests may provide a mock implementation.
         """
 
         self.progress_handler = progress_handler or ProgressBarHandler()
@@ -40,8 +43,8 @@ class YoutubeDownloader:
 
     def _create_youtube(
         self, url: str, progress_handler: ProgressHandler | None
-    ) -> YouTube | None:
-        """Instantiate ``YouTube`` and register the progress callback.
+    ) -> YouTubeVideo | None:
+        """Instantiate a video object and register the progress callback.
 
         This wrapper centralises error handling around the ``youtube_cls``
         factory provided at construction time.  It returns ``None`` if the
@@ -111,13 +114,13 @@ class YoutubeDownloader:
             self.conversion_mp4_in_mp3(out_file)
 
     def streams_video(
-        self, download_sound_only: bool, youtube_video: YouTube
+        self, download_sound_only: bool, youtube_video: YouTubeVideo
     ) -> Optional[Any]:
         """Return the available streams for ``youtube_video``.
 
         Args:
             download_sound_only: Ignored, kept for backward compatibility.
-            youtube_video: An instance of :class:`pytubefix.YouTube`.
+            youtube_video: An object implementing :class:`YouTubeVideo`.
 
         Returns:
             The list of available streams or ``None`` if retrieval failed.

--- a/program_youtube_downloader/types.py
+++ b/program_youtube_downloader/types.py
@@ -1,0 +1,14 @@
+from typing import Protocol, Any
+
+
+class YouTubeVideo(Protocol):
+    """Minimal interface required from pytube ``YouTube`` objects."""
+
+    streams: Any
+
+    @property
+    def title(self) -> str:  # pragma: no cover - typing stub
+        ...
+
+    def register_on_progress_callback(self, cb) -> None:  # pragma: no cover - typing stub
+        ...

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -12,6 +12,7 @@ from program_youtube_downloader.exceptions import DownloadError
 from program_youtube_downloader.config import DownloadOptions
 from program_youtube_downloader.progress import progress_bar, ProgressBarHandler
 from program_youtube_downloader import constants
+from program_youtube_downloader.types import YouTubeVideo
 
 
 # Helper dummy classes reused across tests
@@ -34,7 +35,7 @@ class DummyStreams(list):
         return self[0]
 
 
-class DummyYT:
+class DummyYT(YouTubeVideo):
     def __init__(self, url: str) -> None:
         self.url = url
         self._title = "video"

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -5,6 +5,7 @@ from program_youtube_downloader import cli_utils
 from program_youtube_downloader.downloader import YoutubeDownloader
 from program_youtube_downloader.config import DownloadOptions
 from program_youtube_downloader.exceptions import DownloadError
+from program_youtube_downloader.types import YouTubeVideo
 
 class DummyStream:
     itag = 1
@@ -21,12 +22,16 @@ class DummyStreams(list):
     def get_by_itag(self, itag: int) -> DummyStream:
         return self[0]
 
-class DummyYT:
+class DummyYT(YouTubeVideo):
     def __init__(self, url: str) -> None:
         self.url = url
-        self.title = "video"
+        self._title = "video"
         self.streams: DummyStreams = DummyStreams([DummyStream()])
         self.progress = None
+
+    @property
+    def title(self):
+        return self._title
 
     def register_on_progress_callback(self, cb) -> None:
         self.progress = cb


### PR DESCRIPTION
## Summary
- define `YouTubeVideo` protocol describing the minimal interface of pytube objects
- type `youtube_cls` in `YoutubeDownloader` so it returns a `YouTubeVideo`
- update dummy objects in tests to implement the protocol

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a2b9bfd08321bb56ade9a20b321f