### PR TITLE
Add integration tests for interactive menu

### DIFF
--- a/tests/test_menu_integration.py
+++ b/tests/test_menu_integration.py
@@ -1,0 +1,34 @@
+import program_youtube_downloader.main as main_module
+from program_youtube_downloader.config import DownloadOptions
+
+
+class DummyDownloader:
+    def __init__(self):
+        self.called = None
+
+    def download_multiple_videos(self, urls, options):
+        self.called = (list(urls), options)
+
+
+def run_menu_with_choice(monkeypatch, tmp_path, menu_choice):
+    dd = DummyDownloader()
+    monkeypatch.setattr(main_module, "YoutubeDownloader", lambda: dd)
+    monkeypatch.setattr(main_module.cli_utils, "afficher_menu_acceuil", lambda: len(main_module.MenuOption))
+    choices = iter([menu_choice, main_module.MenuOption.QUIT.value])
+    monkeypatch.setattr(main_module.cli_utils, "ask_numeric_value", lambda a, b: next(choices))
+    monkeypatch.setattr(main_module.cli_utils, "ask_youtube_url", lambda: "https://youtu.be/x")
+    monkeypatch.setattr(main_module, "create_download_options", lambda ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
+    main_module.menu()
+    return dd.called
+
+
+def test_menu_video_triggers_download(monkeypatch, tmp_path):
+    called = run_menu_with_choice(monkeypatch, tmp_path, main_module.MenuOption.VIDEO.value)
+    assert called[0] == ["https://youtu.be/x"]
+    assert called[1].download_sound_only is False
+
+
+def test_menu_audio_only_triggers_download(monkeypatch, tmp_path):
+    called = run_menu_with_choice(monkeypatch, tmp_path, main_module.MenuOption.VIDEO_AUDIO_ONLY.value)
+    assert called[0] == ["https://youtu.be/x"]
+    assert called[1].download_sound_only is True

--- a/tests/tests_overview.md
+++ b/tests/tests_overview.md
@@ -50,6 +50,12 @@ Couvre des cas supplémentaires pour les utilitaires et le point d’entrée pri
 - cas limites supplémentaires pour la sélection de chemin et l’analyse de fichiers d’URLs
 - tests de type intégration pour les commandes vidéo, playlist, chaîne et menu
 
+## `test_menu_integration.py`
+
+Valide la fonction interactive `menu()` en simulant les entrées utilisateur avec
+`monkeypatch`. Les tests s’assurent qu’un téléchargement est lancé avec les
+bonnes options (vidéo ou audio uniquement) selon le choix fourni.
+
 ## `test_validators.py`
 
 Confirme que `validate_youtube_url` accepte les URLs valides de YouTube et rejette celles malformées.


### PR DESCRIPTION
## Summary
- test that the `menu()` function triggers a download using monkeypatched inputs
- describe the new menu tests in `tests_overview.md`

## Testing
- `pytest tests/test_menu_integration.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844aa1a5ee88321b9c2f4f918098a90