### PR TITLE
Add logging configuration helper

### DIFF
--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -5,6 +5,16 @@ import argparse
 import logging
 from pathlib import Path
 
+
+def setup_logging(level: str) -> None:
+    """Configure application-wide logging."""
+    logging.basicConfig(
+        level=getattr(logging, level.upper(), logging.ERROR),
+        format="%(levelname)s:%(name)s:%(message)s",
+        force=True,
+    )
+
+
 logger = logging.getLogger(__name__)
 import os
 
@@ -215,7 +225,7 @@ def main(argv: list[str] | None = None) -> None:
         argv: Optional list of command line arguments.
     """
     args = parse_args(argv)
-    logging.getLogger().setLevel(args.log_level)
+    setup_logging(args.log_level)
     command = args.command
     yd = YoutubeDownloader()
 

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,12 @@
+import logging
+import program_youtube_downloader.main as main_module
+
+
+def test_setup_logging_configures_level(caplog):
+    main_module.setup_logging("INFO")
+    logging.getLogger().addHandler(caplog.handler)
+    logger = logging.getLogger("dummy")
+    logger.debug("debug")
+    logger.info("info")
+    assert "info" in caplog.text
+    assert "debug" not in caplog.text


### PR DESCRIPTION
## Summary
- add `setup_logging` helper to configure root logger
- call `setup_logging` from `main()`
- test logging configuration via `caplog`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844ac1f2a248321a3858815321edcfc