### PR TITLE
Refactor progress bar with dataclass

### DIFF
--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -30,7 +30,8 @@ Fonctions d'interaction utilisateur :
 
 ## `progress.py`
 - `on_download_progress(stream, chunk, remaining)` : gestionnaire simple de progression.
-- `progress_bar(progress, size=35, ...)` : affiche une barre de progression dans le terminal.
+- `ProgressOptions` : configuration de l'affichage de la barre.
+- `progress_bar(progress, options=None)` : affiche une barre de progression dans le terminal.
 - `ProgressBarHandler` : implémente `on_progress` pour `pytubefix`.
 
 ## `config.py`

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -1,4 +1,5 @@
 import sys
+from dataclasses import dataclass
 from typing import Protocol
 
 import colorama
@@ -10,48 +11,70 @@ init(autoreset=True)
 class ProgressHandler(Protocol):
     """Interface for receiving progress events from pytube."""
 
-    def on_progress(self, stream, chunk, bytes_remaining) -> None:  # pragma: no cover - typing
+    def on_progress(
+        self, stream, chunk, bytes_remaining
+    ) -> None:  # pragma: no cover - typing
         """Handle a download progress event."""
         raise NotImplementedError
 
 
-def on_download_progress(stream, chunk, bytes_remaining) -> None:  # pragma: no cover - legacy
+def on_download_progress(
+    stream, chunk, bytes_remaining
+) -> None:  # pragma: no cover - legacy
     """Backward compatible wrapper around :class:`ProgressBarHandler`."""
     ProgressBarHandler().on_progress(stream, chunk, bytes_remaining)
 
 
-def progress_bar(
-    progress: float,
-    size: int = 35,
-    sides: str = "||",
-    full: str = "█",
-    empty: str = " ",
-    prefix_start: str = "Downloading ...",
-    prefix_end: str = "Download OK ...",
-    color_text: str = colorama.Fore.WHITE,
-    color_Downloading: str = colorama.Fore.LIGHTYELLOW_EX,
-    color_Download_OK: str = colorama.Fore.GREEN,
-) -> None:
+@dataclass
+class ProgressOptions:
+    """Configuration for :func:`progress_bar`."""
+
+    size: int = 35
+    sides: str = "||"
+    full: str = "█"
+    empty: str = " "
+    prefix_start: str = "Downloading ..."
+    prefix_end: str = "Download OK ..."
+    color_text: str = colorama.Fore.WHITE
+    color_Downloading: str = colorama.Fore.LIGHTYELLOW_EX
+    color_Download_OK: str = colorama.Fore.GREEN
+
+
+def progress_bar(progress: float, options: ProgressOptions | None = None) -> None:
     """Print a textual progress bar to standard output.
 
     Args:
         progress: Percentage of completion between 0 and 100.
-        size: Width of the bar in characters.
-        sides: Two characters used to wrap the bar (left then right).
-        full: Character representing completed segments.
-        empty: Character representing remaining segments.
-        prefix_start: Text displayed while downloading.
-        prefix_end: Text displayed when ``progress`` reaches 100.
-        color_text: Color for the text prefix.
-        color_Downloading: Color for the bar while downloading.
-        color_Download_OK: Color for the bar when finished.
+        options: Display configuration. If ``None`` defaults are used.
     """
-    x = int(size * progress / 100)
-    bar = sides[0] + full * x + empty * (size - x) + sides[1]
-    sys.stdout.write(color_text + "\r" + prefix_start + color_Downloading + bar + f" {progress:.2f}% ")
+    if options is None:
+        options = ProgressOptions()
+
+    x = int(options.size * progress / 100)
+    bar = (
+        options.sides[0]
+        + options.full * x
+        + options.empty * (options.size - x)
+        + options.sides[1]
+    )
+    sys.stdout.write(
+        options.color_text
+        + "\r"
+        + options.prefix_start
+        + options.color_Downloading
+        + bar
+        + f" {progress:.2f}% "
+    )
 
     if progress == 100:
-        sys.stdout.write("\r" + color_text + prefix_end + color_Download_OK + bar + f" {progress:.2f}% ")
+        sys.stdout.write(
+            "\r"
+            + options.color_text
+            + options.prefix_end
+            + options.color_Download_OK
+            + bar
+            + f" {progress:.2f}% "
+        )
         print(colorama.Fore.RESET)
 
     sys.stdout.flush()
@@ -60,9 +83,12 @@ def progress_bar(
 class ProgressBarHandler:
     """Default progress handler displaying a textual bar."""
 
+    def __init__(self, options: ProgressOptions | None = None) -> None:
+        self.options = options
+
     def on_progress(self, stream, chunk, bytes_remaining) -> None:
         """Compute percentage and forward it to :func:`progress_bar`."""
         total_bytes_download = stream.filesize
         bytes_downloaded = stream.filesize - bytes_remaining
         progress = (bytes_downloaded / total_bytes_download) * 100
-        progress_bar(progress)
+        progress_bar(progress, self.options)

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -10,7 +10,11 @@ from program_youtube_downloader import cli_utils, youtube_downloader
 from program_youtube_downloader.downloader import YoutubeDownloader
 from program_youtube_downloader.exceptions import DownloadError, StreamAccessError
 from program_youtube_downloader.config import DownloadOptions
-from program_youtube_downloader.progress import progress_bar, ProgressBarHandler
+from program_youtube_downloader.progress import (
+    progress_bar,
+    ProgressBarHandler,
+    ProgressOptions,
+)
 from program_youtube_downloader import constants
 from program_youtube_downloader.types import YouTubeVideo
 
@@ -54,6 +58,7 @@ class DummyYT(YouTubeVideo):
 # CLI utility helpers
 # ---------------------------------------------------------------------------
 
+
 def test_afficher_menu_acceuil_count(monkeypatch):
     """The menu should display all choices and return their count."""
     printed = []
@@ -82,16 +87,30 @@ def test_demander_choice_resolution_video(monkeypatch):
     """Video resolution flow mirrors the audio version."""
     streams = [SimpleNamespace(resolution="360p"), SimpleNamespace(resolution="720p")]
     monkeypatch.setattr(cli_utils, "ask_numeric_value", lambda a, b: 1)
-    assert cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio(False, streams) == 1
+    assert (
+        cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio(False, streams) == 1
+    )
 
 
 # ---------------------------------------------------------------------------
 # Progress handling
 # ---------------------------------------------------------------------------
 
+
 def test_progress_bar_outputs(capsys):
     """Ensure the textual progress bar displays expected markers."""
-    progress_bar(50, size=10, sides="[]", full="#", empty="-", prefix_start="", prefix_end="", color_text="", color_Downloading="", color_Download_OK="")
+    opts = ProgressOptions(
+        size=10,
+        sides="[]",
+        full="#",
+        empty="-",
+        prefix_start="",
+        prefix_end="",
+        color_text="",
+        color_Downloading="",
+        color_Download_OK="",
+    )
+    progress_bar(50, opts)
     out = capsys.readouterr().out
     assert "[#####-----]" in out
     assert "50.00%" in out
@@ -109,6 +128,7 @@ def test_progressbarhandler_on_progress(capsys):
 # ---------------------------------------------------------------------------
 # Small helpers from youtube_downloader module
 # ---------------------------------------------------------------------------
+
 
 def test_program_break_time(monkeypatch, capsys):
     """Countdown should print remaining seconds without sleeping when patched."""
@@ -139,6 +159,7 @@ def test_clear_screen(monkeypatch):
 # ---------------------------------------------------------------------------
 # YoutubeDownloader specific behaviour
 # ---------------------------------------------------------------------------
+
 
 def test_streams_video_http_error(monkeypatch):
     """HTTP errors when accessing streams should raise StreamAccessError."""
@@ -197,7 +218,9 @@ def test_download_multiple_videos_title_keyerror(monkeypatch, tmp_path):
         def title(self):
             raise KeyError("missing")
 
-    monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
+    monkeypatch.setattr(
+        YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams
+    )
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
     monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
@@ -210,7 +233,9 @@ def test_download_multiple_videos_title_keyerror(monkeypatch, tmp_path):
 
 def test_download_multiple_videos_default_choice(monkeypatch, tmp_path):
     """When no callback is provided, the first stream is used."""
-    monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
+    monkeypatch.setattr(
+        YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams
+    )
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
     monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
@@ -232,7 +257,9 @@ def test_download_multiple_videos_download_error(monkeypatch, tmp_path):
             super().__init__(url)
             self.streams = DummyStreams([FailingStream()])
 
-    monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
+    monkeypatch.setattr(
+        YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams
+    )
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
     monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -5,13 +5,17 @@ from types import SimpleNamespace
 
 import pytest
 
-from program_youtube_downloader import cli_utils, progress, validators, youtube_downloader
+from program_youtube_downloader import (
+    cli_utils,
+    progress,
+    validators,
+    youtube_downloader,
+)
 import program_youtube_downloader.main as main_module
 
 
 def test_progress_bar_complete(capsys):
-    progress.progress_bar(
-        100,
+    opts = progress.ProgressOptions(
         size=10,
         sides="[]",
         full="#",
@@ -22,6 +26,7 @@ def test_progress_bar_complete(capsys):
         color_Downloading="",
         color_Download_OK="",
     )
+    progress.progress_bar(100, opts)
     out = capsys.readouterr().out
     assert "[##########]" in out
     assert "100.00%" in out
@@ -99,7 +104,9 @@ def test_demander_youtube_link_file_oserror(monkeypatch, tmp_path):
     bad = tmp_path / "bad.txt"
     inputs = iter([str(bad), str(bad), str(bad)])
     monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
-    monkeypatch.setattr(Path, "open", lambda self, *a, **k: (_ for _ in ()).throw(OSError()))
+    monkeypatch.setattr(
+        Path, "open", lambda self, *a, **k: (_ for _ in ()).throw(OSError())
+    )
     with pytest.raises(cli_utils.ValidationError):
         cli_utils.demander_youtube_link_file()
 
@@ -113,8 +120,12 @@ def test_print_end_download_message(caplog):
 def test_pause_return_to_menu(monkeypatch):
     called = {}
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
-    monkeypatch.setattr(cli_utils, "program_break_time", lambda t, m: called.setdefault("break", (t, m)))
-    monkeypatch.setattr(cli_utils, "clear_screen", lambda: called.setdefault("clear", True))
+    monkeypatch.setattr(
+        cli_utils, "program_break_time", lambda t, m: called.setdefault("break", (t, m))
+    )
+    monkeypatch.setattr(
+        cli_utils, "clear_screen", lambda: called.setdefault("clear", True)
+    )
     cli_utils.pause_return_to_menu()
     assert called["break"] == (3, "Le menu d'accueil va revenir dans")
     assert called["clear"] is True
@@ -129,7 +140,9 @@ class DummyDownloader:
 
 
 def test_create_download_options(monkeypatch, tmp_path):
-    monkeypatch.setattr(main_module.cli_utils, "demander_save_file_path", lambda: tmp_path)
+    monkeypatch.setattr(
+        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+    )
     monkeypatch.setattr(
         main_module.cli_utils,
         "demander_choice_resolution_vidéo_or_bitrate_audio",
@@ -138,14 +151,23 @@ def test_create_download_options(monkeypatch, tmp_path):
     opt = main_module.create_download_options(True)
     assert opt.save_path == tmp_path
     assert opt.download_sound_only is True
-    assert opt.choice_callback is main_module.cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio
+    assert (
+        opt.choice_callback
+        is main_module.cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio
+    )
 
 
 def test_main_video_command(monkeypatch, tmp_path):
     dd = DummyDownloader()
     monkeypatch.setattr(main_module, "YoutubeDownloader", lambda: dd)
-    monkeypatch.setattr(main_module.cli_utils, "demander_save_file_path", lambda: tmp_path)
-    monkeypatch.setattr(main_module.cli_utils, "demander_choice_resolution_vidéo_or_bitrate_audio", lambda *a, **k: 1)
+    monkeypatch.setattr(
+        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        main_module.cli_utils,
+        "demander_choice_resolution_vidéo_or_bitrate_audio",
+        lambda *a, **k: 1,
+    )
     main_module.main(["video", "https://youtu.be/x"])
     assert dd.called[0] == ["https://youtu.be/x"]
     assert dd.called[1].save_path == tmp_path
@@ -155,9 +177,17 @@ def test_main_video_command(monkeypatch, tmp_path):
 def test_main_playlist_command(monkeypatch, tmp_path):
     dd = DummyDownloader()
     monkeypatch.setattr(main_module, "YoutubeDownloader", lambda: dd)
-    monkeypatch.setattr(main_module.youtube_downloader, "Playlist", lambda u: ["https://youtu.be/1"])
-    monkeypatch.setattr(main_module.cli_utils, "demander_save_file_path", lambda: tmp_path)
-    monkeypatch.setattr(main_module.cli_utils, "demander_choice_resolution_vidéo_or_bitrate_audio", lambda *a, **k: 1)
+    monkeypatch.setattr(
+        main_module.youtube_downloader, "Playlist", lambda u: ["https://youtu.be/1"]
+    )
+    monkeypatch.setattr(
+        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        main_module.cli_utils,
+        "demander_choice_resolution_vidéo_or_bitrate_audio",
+        lambda *a, **k: 1,
+    )
     main_module.main(["playlist", "https://example.com/playlist"])
     assert dd.called[0] == ["https://youtu.be/1"]
     assert dd.called[1].save_path == tmp_path
@@ -166,9 +196,17 @@ def test_main_playlist_command(monkeypatch, tmp_path):
 def test_main_channel_command(monkeypatch, tmp_path):
     dd = DummyDownloader()
     monkeypatch.setattr(main_module, "YoutubeDownloader", lambda: dd)
-    monkeypatch.setattr(main_module.youtube_downloader, "Channel", lambda u: ["https://youtu.be/2"])
-    monkeypatch.setattr(main_module.cli_utils, "demander_save_file_path", lambda: tmp_path)
-    monkeypatch.setattr(main_module.cli_utils, "demander_choice_resolution_vidéo_or_bitrate_audio", lambda *a, **k: 1)
+    monkeypatch.setattr(
+        main_module.youtube_downloader, "Channel", lambda u: ["https://youtu.be/2"]
+    )
+    monkeypatch.setattr(
+        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+    )
+    monkeypatch.setattr(
+        main_module.cli_utils,
+        "demander_choice_resolution_vidéo_or_bitrate_audio",
+        lambda *a, **k: 1,
+    )
     main_module.main(["channel", "https://example.com/channel"])
     assert dd.called[0] == ["https://youtu.be/2"]
 


### PR DESCRIPTION
## Summary
- encapsulate progress bar parameters in `ProgressOptions`
- accept `ProgressOptions` in `progress_bar` and `ProgressBarHandler`
- update tests and API reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b160d86c8321a23611dad8977d61