### PR TITLE
Rename French cli helper names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Utilisation :
 **Points d'entrée** :
 - `ask_numeric_value()` dans [program_youtube_downloader/cli_utils.py](program_youtube_downloader/cli_utils.py) lignes 22-39.
 - `ask_youtube_url()` dans [program_youtube_downloader/cli_utils.py](program_youtube_downloader/cli_utils.py) lignes 96-113.
-- `demander_youtube_link_file()` dans [program_youtube_downloader/cli_utils.py](program_youtube_downloader/cli_utils.py) lignes 115-159.
+- `ask_youtube_link_file()` dans [program_youtube_downloader/cli_utils.py](program_youtube_downloader/cli_utils.py) lignes 115-159.
 - `validate_youtube_url()` dans [program_youtube_downloader/validators.py](program_youtube_downloader/validators.py) lignes 4-18.
 
 **Entrées** : valeurs saisies par l'utilisateur.
@@ -104,7 +104,7 @@ value = ask_numeric_value(1, 3)
 | Agent de téléchargement | `downloader.py` | `download_multiple_videos` |
 | Agent de conversion | `downloader.py` | `conversion_mp4_in_mp3` |
 | Agent de progression | `program_youtube_downloader/progress.py` | `on_download_progress`, `progress_bar` |
-| Agent de validation | `program_youtube_downloader/cli_utils.py` | `ask_numeric_value`, `ask_youtube_url`, `demander_youtube_link_file` |
+| Agent de validation | `program_youtube_downloader/cli_utils.py` | `ask_numeric_value`, `ask_youtube_url`, `ask_youtube_link_file` |
 | Agent des constantes | `program_youtube_downloader/constants.py` | libellés du menu, `BASE_YOUTUBE_URL` |
 | Agent de configuration | `program_youtube_downloader/config.py` | dataclass `DownloadOptions` |
 

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -17,11 +17,11 @@ Cette section décrit brièvement les fonctions et classes disponibles dans le p
 Fonctions d'interaction utilisateur :
 - `print_separator()` : affiche un séparateur visuel.
 - `ask_numeric_value(min, max)` : demande une valeur numérique.
-- `afficher_menu_acceuil()` : affiche le menu principal et retourne le nombre de choix.
-- `demander_save_file_path()` : demande un dossier de destination et le crée au besoin.
+- `display_main_menu()` : affiche le menu principal et retourne le nombre de choix.
+- `ask_save_file_path()` : demande un dossier de destination et le crée au besoin.
 - `ask_youtube_url()` : invite l'utilisateur à saisir une URL YouTube et la valide.
-- `demander_youtube_link_file()` : lit un fichier contenant des URLs YouTube.
-- `demander_choice_resolution_vidéo_or_bitrate_audio(sound_only, streams)` : sélectionne la qualité désirée.
+- `ask_youtube_link_file()` : lit un fichier contenant des URLs YouTube.
+- `ask_resolution_or_bitrate(sound_only, streams)` : sélectionne la qualité désirée.
 - `print_end_download_message()` : indique la fin du téléchargement.
 - `pause_return_to_menu()` : attend une touche avant de revenir au menu.
 

--- a/docs/overview_fr.md
+++ b/docs/overview_fr.md
@@ -23,7 +23,7 @@ Un tableau récapitulatif liste chaque agent avec son fichier et ses fonctions p
 ## Fonctionnement général
 
 1. L'utilisateur lance `program-youtube-downloader` depuis le terminal.
-2. Le **menu interactif** (ou une sous-commande) propose différents choix : télécharger une vidéo, plusieurs vidéos, une playlist, etc. Les options sont définies dans `constants.py` et affichées par `cli_utils.afficher_menu_acceuil`.
+2. Le **menu interactif** (ou une sous-commande) propose différents choix : télécharger une vidéo, plusieurs vidéos, une playlist, etc. Les options sont définies dans `constants.py` et affichées par `cli_utils.display_main_menu`.
 3. Les saisies de l'utilisateur (URL, dossier de destination, choix de résolution) sont validées par `cli_utils.py` et `validators.py`.
 4. Le téléchargeur (`YoutubeDownloader`) récupère les flux via `pytubefix`, affiche une barre de progression grâce au `ProgressBarHandler`, enregistre le fichier puis convertit en MP3 si nécessaire. Tout cela est orchestré par `download_multiple_videos`.
 5. `cli_utils.print_end_download_message` et `cli_utils.pause_return_to_menu` signalent la fin du téléchargement et renvoient l'utilisateur au menu principal.

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -66,12 +66,8 @@ def ask_numeric_value(valeur_min: int, valeur_max: int, max_attempts: int = 3) -
         return v_int
 
 
-def afficher_menu_acceuil() -> int:
-    """Display the main menu.
-
-    Returns:
-        The number of available choices presented to the user.
-    """
+def display_main_menu() -> int:
+    """Display the main menu and return the number of choices."""
     print()
     print()
     print_separator()
@@ -91,7 +87,7 @@ def afficher_menu_acceuil() -> int:
     return valeur_choix_maximale
 
 
-def demander_save_file_path(max_attempts: int = 3) -> Path:
+def ask_save_file_path(max_attempts: int = 3) -> Path:
     """Prompt for a destination directory and create it if necessary.
 
     Args:
@@ -177,7 +173,7 @@ def ask_youtube_url(max_attempts: int = 3) -> str:
             raise ValidationError("URL invalide")
 
 
-def demander_youtube_link_file(max_attempts: int = 3) -> list[str]:
+def ask_youtube_link_file(max_attempts: int = 3) -> list[str]:
     """Load a list of YouTube URLs from a text file.
 
     Args:
@@ -247,7 +243,7 @@ def demander_youtube_link_file(max_attempts: int = 3) -> list[str]:
         return link_url_video_youtube_final
 
 
-def demander_choice_resolution_vidéo_or_bitrate_audio(
+def ask_resolution_or_bitrate(
     download_sound_only: bool, list_available_streams: Iterable[Any]
 ) -> int:
     """Prompt the user to choose a resolution or bitrate from ``list_available_streams``.

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -95,11 +95,11 @@ def create_download_options(audio_only: bool, output_dir: Path | None = None) ->
     if output_dir is not None:
         save_path = output_dir.expanduser().resolve()
     else:
-        save_path = cli_utils.demander_save_file_path()
+        save_path = cli_utils.ask_save_file_path()
     return DownloadOptions(
         save_path=save_path,
         download_sound_only=audio_only,
-        choice_callback=cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio,
+        choice_callback=cli_utils.ask_resolution_or_bitrate,
     )
 
 
@@ -123,7 +123,7 @@ def handle_video_option(yd: YoutubeDownloader, audio_only: bool) -> None:
 
 def handle_videos_option(yd: YoutubeDownloader, audio_only: bool) -> None:
     """Download multiple videos or their audio tracks from a file."""
-    urls = cli_utils.demander_youtube_link_file()
+    urls = cli_utils.ask_youtube_link_file()
     options = create_download_options(audio_only)
     yd.download_multiple_videos(urls, options)
 
@@ -161,7 +161,7 @@ def menu() -> None:  # pragma: no cover
     yd = YoutubeDownloader()
 
     while True:
-        choix_max_menu_accueil = cli_utils.afficher_menu_acceuil()
+        choix_max_menu_accueil = cli_utils.display_main_menu()
         choix = MenuOption(cli_utils.ask_numeric_value(1, choix_max_menu_accueil))
 
         match choix:

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -59,16 +59,16 @@ class DummyYT(YouTubeVideo):
 # ---------------------------------------------------------------------------
 
 
-def test_afficher_menu_acceuil_count(monkeypatch):
+def test_display_main_menu_count(monkeypatch):
     """The menu should display all choices and return their count."""
     printed = []
     monkeypatch.setattr(builtins, "print", lambda *a, **k: printed.append(a))
-    count = cli_utils.afficher_menu_acceuil()
+    count = cli_utils.display_main_menu()
     assert count == len(constants.MenuOption)
     assert any("1 -" in " ".join(map(str, args)) for args in printed)
 
 
-def test_demander_choice_resolution_audio(monkeypatch):
+def test_ask_resolution_or_bitrate_audio(monkeypatch):
     """Selection of audio bitrate should delegate range checking."""
     streams = [SimpleNamespace(abr="64k"), SimpleNamespace(abr="128k")]
     called = {}
@@ -78,17 +78,17 @@ def test_demander_choice_resolution_audio(monkeypatch):
         return 2
 
     monkeypatch.setattr(cli_utils, "ask_numeric_value", fake_numeric)
-    choice = cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio(True, streams)
+    choice = cli_utils.ask_resolution_or_bitrate(True, streams)
     assert choice == 2
     assert called["range"] == (1, len(streams))
 
 
-def test_demander_choice_resolution_video(monkeypatch):
+def test_ask_resolution_or_bitrate_video(monkeypatch):
     """Video resolution flow mirrors the audio version."""
     streams = [SimpleNamespace(resolution="360p"), SimpleNamespace(resolution="720p")]
     monkeypatch.setattr(cli_utils, "ask_numeric_value", lambda a, b: 1)
     assert (
-        cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio(False, streams) == 1
+        cli_utils.ask_resolution_or_bitrate(False, streams) == 1
     )
 
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -39,33 +39,33 @@ def test_ask_youtube_url_invalid_then_valid(monkeypatch):
     assert url == "https://www.youtube.com/watch?v=good"
 
 
-def test_demander_save_file_path_existing(tmp_path, monkeypatch):
+def test_ask_save_file_path_existing(tmp_path, monkeypatch):
     inputs = iter([str(tmp_path)])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
-    p = cli_utils.demander_save_file_path()
+    p = cli_utils.ask_save_file_path()
     assert p == tmp_path.resolve()
 
 
-def test_demander_save_file_path_create(tmp_path, monkeypatch):
+def test_ask_save_file_path_create(tmp_path, monkeypatch):
     new_dir = tmp_path / "newdir"
     inputs = iter([str(new_dir), "y"])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
-    p = cli_utils.demander_save_file_path()
+    p = cli_utils.ask_save_file_path()
     assert p == new_dir.resolve()
     assert new_dir.exists()
 
 
-def test_demander_save_file_path_retry(monkeypatch, tmp_path):
+def test_ask_save_file_path_retry(monkeypatch, tmp_path):
     missing = tmp_path / "missing"
     existing = tmp_path / "exists"
     existing.mkdir()
     inputs = iter([str(missing), "n", str(existing)])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
-    p = cli_utils.demander_save_file_path()
+    p = cli_utils.ask_save_file_path()
     assert p == existing.resolve()
 
 
-def test_demander_save_file_path_mkdir_failure(monkeypatch, tmp_path):
+def test_ask_save_file_path_mkdir_failure(monkeypatch, tmp_path):
     new_dir = tmp_path / "newdir"
     inputs = iter([str(new_dir), "y", str(tmp_path)])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
@@ -77,18 +77,18 @@ def test_demander_save_file_path_mkdir_failure(monkeypatch, tmp_path):
     fail_once.calls = 0
     monkeypatch.setattr(Path, "mkdir", fail_once)
 
-    result = cli_utils.demander_save_file_path()
+    result = cli_utils.ask_save_file_path()
     assert result == tmp_path.resolve()
 
 
-def test_demander_youtube_link_file(monkeypatch, tmp_path):
+def test_ask_youtube_link_file(monkeypatch, tmp_path):
     links_file = tmp_path / "links.txt"
     links_file.write_text(
         "https://www.youtube.com/watch?v=ok\ninvalid\nhttps://youtu.be/abc\n"
     )
     inputs = iter([str(links_file)])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
-    links = cli_utils.demander_youtube_link_file()
+    links = cli_utils.ask_youtube_link_file()
     assert links == [
         "https://www.youtube.com/watch?v=ok",
         "https://youtu.be/abc",

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -62,16 +62,16 @@ def test_clear_screen_windows(monkeypatch):
     assert called.get("check") is True
 
 
-def test_demander_save_file_path_file(monkeypatch, tmp_path):
+def test_ask_save_file_path_file(monkeypatch, tmp_path):
     file_p = tmp_path / "file.txt"
     file_p.write_text("x")
     inputs = iter([str(file_p)])
     monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
-    result = cli_utils.demander_save_file_path()
+    result = cli_utils.ask_save_file_path()
     assert result == tmp_path.resolve()
 
 
-def test_demander_save_file_path_mkdir_error(monkeypatch, tmp_path):
+def test_ask_save_file_path_mkdir_error(monkeypatch, tmp_path):
     new_dir = tmp_path / "newdir"
     inputs = iter([str(new_dir), "y", str(tmp_path)])
     monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
@@ -85,22 +85,22 @@ def test_demander_save_file_path_mkdir_error(monkeypatch, tmp_path):
 
     failing.calls = 0
     monkeypatch.setattr(Path, "mkdir", failing)
-    result = cli_utils.demander_save_file_path()
+    result = cli_utils.ask_save_file_path()
     assert result == tmp_path.resolve()
 
 
-def test_demander_youtube_link_file_all_invalid(monkeypatch, tmp_path):
+def test_ask_youtube_link_file_all_invalid(monkeypatch, tmp_path):
     bad = tmp_path / "bad.txt"
     bad.write_text("not_a_url\n")
     good = tmp_path / "good.txt"
     good.write_text("https://youtu.be/ok\n")
     inputs = iter([str(bad), str(good)])
     monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
-    links = cli_utils.demander_youtube_link_file()
+    links = cli_utils.ask_youtube_link_file()
     assert links == ["https://youtu.be/ok"]
 
 
-def test_demander_youtube_link_file_oserror(monkeypatch, tmp_path):
+def test_ask_youtube_link_file_oserror(monkeypatch, tmp_path):
     bad = tmp_path / "bad.txt"
     inputs = iter([str(bad), str(bad), str(bad)])
     monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
@@ -108,7 +108,7 @@ def test_demander_youtube_link_file_oserror(monkeypatch, tmp_path):
         Path, "open", lambda self, *a, **k: (_ for _ in ()).throw(OSError())
     )
     with pytest.raises(cli_utils.ValidationError):
-        cli_utils.demander_youtube_link_file()
+        cli_utils.ask_youtube_link_file()
 
 
 def test_print_end_download_message(caplog):
@@ -141,11 +141,11 @@ class DummyDownloader:
 
 def test_create_download_options(monkeypatch, tmp_path):
     monkeypatch.setattr(
-        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+        main_module.cli_utils, "ask_save_file_path", lambda: tmp_path
     )
     monkeypatch.setattr(
         main_module.cli_utils,
-        "demander_choice_resolution_vidéo_or_bitrate_audio",
+        "ask_resolution_or_bitrate",
         lambda *a, **k: 99,
     )
     opt = main_module.create_download_options(True)
@@ -153,7 +153,7 @@ def test_create_download_options(monkeypatch, tmp_path):
     assert opt.download_sound_only is True
     assert (
         opt.choice_callback
-        is main_module.cli_utils.demander_choice_resolution_vidéo_or_bitrate_audio
+        is main_module.cli_utils.ask_resolution_or_bitrate
     )
 
 
@@ -161,11 +161,11 @@ def test_main_video_command(monkeypatch, tmp_path):
     dd = DummyDownloader()
     monkeypatch.setattr(main_module, "YoutubeDownloader", lambda: dd)
     monkeypatch.setattr(
-        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+        main_module.cli_utils, "ask_save_file_path", lambda: tmp_path
     )
     monkeypatch.setattr(
         main_module.cli_utils,
-        "demander_choice_resolution_vidéo_or_bitrate_audio",
+        "ask_resolution_or_bitrate",
         lambda *a, **k: 1,
     )
     main_module.main(["video", "https://youtu.be/x"])
@@ -181,11 +181,11 @@ def test_main_playlist_command(monkeypatch, tmp_path):
         main_module.youtube_downloader, "Playlist", lambda u: ["https://youtu.be/1"]
     )
     monkeypatch.setattr(
-        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+        main_module.cli_utils, "ask_save_file_path", lambda: tmp_path
     )
     monkeypatch.setattr(
         main_module.cli_utils,
-        "demander_choice_resolution_vidéo_or_bitrate_audio",
+        "ask_resolution_or_bitrate",
         lambda *a, **k: 1,
     )
     main_module.main(["playlist", "https://example.com/playlist"])
@@ -200,11 +200,11 @@ def test_main_channel_command(monkeypatch, tmp_path):
         main_module.youtube_downloader, "Channel", lambda u: ["https://youtu.be/2"]
     )
     monkeypatch.setattr(
-        main_module.cli_utils, "demander_save_file_path", lambda: tmp_path
+        main_module.cli_utils, "ask_save_file_path", lambda: tmp_path
     )
     monkeypatch.setattr(
         main_module.cli_utils,
-        "demander_choice_resolution_vidéo_or_bitrate_audio",
+        "ask_resolution_or_bitrate",
         lambda *a, **k: 1,
     )
     main_module.main(["channel", "https://example.com/channel"])

--- a/tests/test_menu_handlers.py
+++ b/tests/test_menu_handlers.py
@@ -25,7 +25,7 @@ def test_handle_video_option(monkeypatch, tmp_path):
 
 def test_handle_videos_option(monkeypatch, tmp_path):
     dd = DummyDownloader()
-    monkeypatch.setattr(main_module.cli_utils, "demander_youtube_link_file", lambda: ["https://youtu.be/a", "https://youtu.be/b"])
+    monkeypatch.setattr(main_module.cli_utils, "ask_youtube_link_file", lambda: ["https://youtu.be/a", "https://youtu.be/b"])
     monkeypatch.setattr(main_module, "create_download_options", lambda ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
     main_module.handle_videos_option(dd, False)
     assert dd.called[0] == ["https://youtu.be/a", "https://youtu.be/b"]

--- a/tests/test_menu_integration.py
+++ b/tests/test_menu_integration.py
@@ -13,7 +13,7 @@ class DummyDownloader:
 def run_menu_with_choice(monkeypatch, tmp_path, menu_choice):
     dd = DummyDownloader()
     monkeypatch.setattr(main_module, "YoutubeDownloader", lambda: dd)
-    monkeypatch.setattr(main_module.cli_utils, "afficher_menu_acceuil", lambda: len(main_module.MenuOption))
+    monkeypatch.setattr(main_module.cli_utils, "display_main_menu", lambda: len(main_module.MenuOption))
     choices = iter([menu_choice, main_module.MenuOption.QUIT.value])
     monkeypatch.setattr(main_module.cli_utils, "ask_numeric_value", lambda a, b: next(choices))
     monkeypatch.setattr(main_module.cli_utils, "ask_youtube_url", lambda: "https://youtu.be/x")

--- a/tests/tests_overview.md
+++ b/tests/tests_overview.md
@@ -39,7 +39,7 @@ Couvre les fonctions d’aide pour les saisies utilisateur :
 
 - validation numérique (`ask_numeric_value`)
 - logique d'entrée d’URL (`ask_youtube_url`)
-- sélection et création de dossier (`demander_save_file_path`)
+- sélection et création de dossier (`ask_save_file_path`)
 - lecture d’un fichier contenant des liens YouTube
 
 ## `test_coverage_more.py`


### PR DESCRIPTION
## Summary
- convert French helper function names in cli_utils.py to English
- update call sites and documentation
- fix tests to use new helper names

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b647327c83218332b75334d6f9be