### PR TITLE
Fix import ordering

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -2,8 +2,6 @@
 
 from pathlib import Path
 import logging
-
-logger = logging.getLogger(__name__)
 from typing import Iterable, Any
 
 from .exceptions import ValidationError
@@ -16,6 +14,8 @@ from .constants import (
 )
 from .youtube_downloader import program_break_time, clear_screen
 from .validators import validate_youtube_url
+
+logger = logging.getLogger(__name__)
 
 
 def print_separator() -> None:

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -3,17 +3,15 @@ from pathlib import Path
 from typing import Optional, Union, Iterable, Callable, Any
 import logging
 
-logger = logging.getLogger(__name__)
-
 from pytubefix import YouTube
 
 from .types import YouTubeVideo
-
 from .exceptions import DownloadError, StreamAccessError
-
 from . import cli_utils
 from .config import DownloadOptions
 from .progress import ProgressHandler, ProgressBarHandler
+
+logger = logging.getLogger(__name__)
 
 
 class YoutubeDownloader:

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -1,9 +1,23 @@
 # main.py
 # pyinstaller --onefile --add-data "mypy.ini;." --hidden-import "youtube_downloader" main.py
+import os
 import sys
 import argparse
 import logging
 from pathlib import Path
+
+
+from . import youtube_downloader
+from . import cli_utils
+from .downloader import YoutubeDownloader
+from .exceptions import PlaylistConnectionError, ChannelConnectionError
+from .config import DownloadOptions
+from .constants import MenuOption
+
+logger = logging.getLogger(__name__)
+
+if '__annotations__' not in globals():
+    __annotations__ = {}
 
 
 def setup_logging(level: str) -> None:
@@ -13,20 +27,6 @@ def setup_logging(level: str) -> None:
         format="%(levelname)s:%(name)s:%(message)s",
         force=True,
     )
-
-
-logger = logging.getLogger(__name__)
-import os
-
-if '__annotations__' not in globals():
-    __annotations__ = {}
-
-from . import youtube_downloader
-from . import cli_utils
-from .downloader import YoutubeDownloader
-from .exceptions import PlaylistConnectionError, ChannelConnectionError
-from .config import DownloadOptions
-from .constants import MenuOption
 
 
 


### PR DESCRIPTION
## Summary
- move imports to the top in `main.py`, `cli_utils.py`, `downloader.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844be61f4188321b0c53ce07e621007