### PR TITLE
Remove unused ProgressBarHandler import

### DIFF
--- a/program_youtube_downloader/config.py
+++ b/program_youtube_downloader/config.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Callable, Any
 
-from .progress import ProgressHandler, ProgressBarHandler
+from .progress import ProgressHandler
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- clean up `DownloadOptions` by dropping unused `ProgressBarHandler` from imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844bf2100748321b5822d68b8fee3f4