### PR TITLE
Fix Python 3.10+ annotations handling

### DIFF
--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -17,9 +17,6 @@ from .constants import MenuOption
 
 logger = logging.getLogger(__name__)
 
-if '__annotations__' not in globals():
-    __annotations__ = {}
-
 
 def setup_logging(level: str) -> None:
     """Configure application-wide logging."""


### PR DESCRIPTION
## Summary
- clean up redundant `__annotations__` fallback from `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c315786c8321b631d42631e38df7