### PR TITLE
Fix file reading encoding

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -199,7 +199,7 @@ def ask_youtube_link_file(max_attempts: int = 3) -> list[str]:
         print()
         try:
             file_path = Path(fichier_user)
-            with file_path.open("r") as fichier:
+            with file_path.open("r", encoding="utf-8") as fichier:
                 lignes = fichier.readlines()
                 compteur_ligne = 0
                 number_erreur = 0


### PR DESCRIPTION
## Summary
- specify UTF-8 encoding when reading URL files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c5d936088321a82e85f4dc382aa8