### PR TITLE
Add AGENTS link to French overview

### DIFF
--- a/docs/overview-fr.md
+++ b/docs/overview-fr.md
@@ -42,3 +42,5 @@ Le dossier `tests/` contient des scripts `pytest` couvrant l'analyse des argumen
 - Pour développer de nouvelles fonctionnalités, créer un nouvel agent ou étendre un agent existant, en documentant son rôle et en écrivant les tests associés.
 
 En résumé, la base de code se compose d'un ensemble de modules Python organisés par responsabilités (*agents*) autour d'un outil CLI. Les fichiers principaux sont simples : un `main` qui traite les arguments ou affiche le menu, un téléchargeur basé sur `pytubefix`, des utilitaires de validation et d'affichage, le tout accompagné d'une suite de tests.
+
+Pour un descriptif détaillé des agents, consultez [AGENTS.md](../AGENTS.md) à la racine du dépôt.


### PR DESCRIPTION
## Summary
- link the root `AGENTS.md` from the French project overview

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e6d8e3f483219c52f9f6aa5389ab