### PR TITLE
Fix logging config

### DIFF
--- a/program_youtube_downloader/youtube_downloader.py
+++ b/program_youtube_downloader/youtube_downloader.py
@@ -10,7 +10,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-logging.basicConfig(level=logging.ERROR)
 
 
 # Projet "Program Youtube Downloader"

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import program_youtube_downloader.main as main_module
 
 
@@ -10,3 +11,18 @@ def test_setup_logging_configures_level(caplog):
     logger.info("info")
     assert "info" in caplog.text
     assert "debug" not in caplog.text
+
+
+def test_youtube_downloader_does_not_configure_logging(monkeypatch):
+    calls = []
+
+    def fake_basicConfig(*args, **kwargs):
+        calls.append((args, kwargs))
+
+    monkeypatch.setattr(logging, "basicConfig", fake_basicConfig)
+    module_name = "program_youtube_downloader.youtube_downloader"
+    sys.modules.pop(module_name, None)
+    import importlib
+
+    importlib.import_module(module_name)
+    assert not calls


### PR DESCRIPTION
## Summary
- remove default logging config from youtube_downloader helper
- ensure no automatic logging configuration on import
- test that logging setup is only applied via setup_logging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459e54a0e48321abed8936b2fac351