### PR TITLE
Move terminal utilities to utils module

### DIFF
--- a/program_youtube_downloader/__init__.py
+++ b/program_youtube_downloader/__init__.py
@@ -1,4 +1,10 @@
 """Public exports for program_youtube_downloader."""
 from .exceptions import DownloadError, ValidationError
+from .utils import clear_screen, program_break_time
 
-__all__ = ["DownloadError", "ValidationError"]
+__all__ = [
+    "DownloadError",
+    "ValidationError",
+    "clear_screen",
+    "program_break_time",
+]

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -11,7 +11,7 @@ from .constants import (
     TITLE_QUESTION_MENU_ACCUEIL,
     CHOICE_MENU_ACCUEIL,
 )
-from .youtube_downloader import program_break_time, clear_screen
+from .utils import program_break_time, clear_screen
 from .validators import validate_youtube_url
 
 logger = logging.getLogger(__name__)

--- a/program_youtube_downloader/utils.py
+++ b/program_youtube_downloader/utils.py
@@ -1,0 +1,36 @@
+"""Miscellaneous utility helpers for console display."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+
+__all__ = ["clear_screen", "program_break_time"]
+
+
+def clear_screen() -> None:
+    """Clear the terminal screen on Windows or POSIX systems."""
+    if os.name == "posix":
+        subprocess.run(["clear"], check=True)
+    else:
+        subprocess.run(["cmd", "/c", "cls"], check=True)
+
+
+def program_break_time(memorization_time: int, affichage_text: str) -> None:
+    """Display a short countdown.
+
+    Args:
+        memorization_time: Duration of the countdown in seconds.
+        affichage_text: Message displayed before the countdown number.
+    """
+    duree_restante_avant_lancement = memorization_time
+    print(
+        f"{affichage_text} {memorization_time} secondes ",
+        end="",
+        flush=True,
+    )
+    while duree_restante_avant_lancement > 0:
+        time.sleep(1)
+        print(f"{duree_restante_avant_lancement} ", end="", flush=True)
+        duree_restante_avant_lancement -= 1

--- a/program_youtube_downloader/youtube_downloader.py
+++ b/program_youtube_downloader/youtube_downloader.py
@@ -1,53 +1,7 @@
-# from asyncio import streams
-# https://github.com/JuanBindez/pytubefix
-# https://pypi.org/project/pytubefix/
-"""Miscellaneous helpers used by the application."""
+"""Backward compatibility utilities (deprecated)."""
 
-import time
-import os
-import subprocess
-import logging
+from __future__ import annotations
 
-logger = logging.getLogger(__name__)
+from .utils import clear_screen, program_break_time
 
-
-
-# Projet "Program Youtube Downloader"
-
-# ------------------------------------------------------------------------------------------- #
-# ----------------------------------- CONSTANTES -------------------------------------------- #
-# ------------------------------------------------------------------------------------------- #
-
-# ------------------------------------------------------------------------------------------- #
-# ----------------------------------- FONCTIONS --------------------------------------------- #
-# ------------------------------------------------------------------------------------------- #
-def clear_screen() -> None:
-    """Clear the terminal screen on Windows or POSIX systems."""
-    if os.name == 'posix':
-        subprocess.run(["clear"], check=True)
-    else:
-        subprocess.run(["cmd", "/c", "cls"], check=True)
-
-
-def program_break_time(memorization_time: int, affichage_text: str) -> None:
-    """Display a short countdown.
-
-    Args:
-        memorization_time: Duration of the countdown in seconds.
-        affichage_text: Message displayed before the countdown number.
-    """
-    duree_restante_avant_lancement = memorization_time
-    print(
-        f"{affichage_text} {memorization_time} secondes ",
-        end="",
-        flush=True,
-    )
-    while duree_restante_avant_lancement > 0:
-        time.sleep(1)
-        print(f"{duree_restante_avant_lancement} ", end="", flush=True)
-        duree_restante_avant_lancement -= 1
-
-
-
-
-
+__all__ = ["clear_screen", "program_break_time"]

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -6,7 +6,7 @@ from urllib.error import HTTPError
 
 import pytest
 
-from program_youtube_downloader import cli_utils, youtube_downloader
+from program_youtube_downloader import cli_utils, utils
 from program_youtube_downloader.downloader import YoutubeDownloader
 from program_youtube_downloader.exceptions import DownloadError, StreamAccessError
 from program_youtube_downloader.config import DownloadOptions
@@ -126,14 +126,14 @@ def test_progressbarhandler_on_progress(capsys):
 
 
 # ---------------------------------------------------------------------------
-# Small helpers from youtube_downloader module
+# Small helpers from utils module
 # ---------------------------------------------------------------------------
 
 
 def test_program_break_time(monkeypatch, capsys):
     """Countdown should print remaining seconds without sleeping when patched."""
-    monkeypatch.setattr(youtube_downloader.time, "sleep", lambda x: None)
-    youtube_downloader.program_break_time(3, "Wait")
+    monkeypatch.setattr(utils.time, "sleep", lambda x: None)
+    utils.program_break_time(3, "Wait")
     out = capsys.readouterr().out
     assert "Wait 3 secondes" in out
     assert "3 2 1" in out
@@ -147,8 +147,8 @@ def test_clear_screen(monkeypatch):
         called["args"] = list(args)
         called.update(kwargs)
 
-    monkeypatch.setattr(youtube_downloader.subprocess, "run", fake_run)
-    youtube_downloader.clear_screen()
+    monkeypatch.setattr(utils.subprocess, "run", fake_run)
+    utils.clear_screen()
     expected = ["clear"] if os.name == "posix" else ["cmd", "/c", "cls"]
     assert called["args"] == expected
     assert called.get("check") is True

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -9,7 +9,7 @@ from program_youtube_downloader import (
     cli_utils,
     progress,
     validators,
-    youtube_downloader,
+    utils,
 )
 import program_youtube_downloader.main as main_module
 
@@ -49,14 +49,14 @@ def test_validate_youtube_url_empty():
 
 def test_clear_screen_windows(monkeypatch):
     called = {}
-    monkeypatch.setattr(youtube_downloader.os, "name", "nt", raising=False)
+    monkeypatch.setattr(utils.os, "name", "nt", raising=False)
 
     def fake_run(args, **kwargs):
         called["args"] = list(args)
         called.update(kwargs)
 
-    monkeypatch.setattr(youtube_downloader.subprocess, "run", fake_run)
-    youtube_downloader.clear_screen()
+    monkeypatch.setattr(utils.subprocess, "run", fake_run)
+    utils.clear_screen()
     assert called["args"] == ["cmd", "/c", "cls"]
     assert "shell" not in called
     assert called.get("check") is True


### PR DESCRIPTION
## Summary
- add new `utils.py` module containing `clear_screen` and `program_break_time`
- re-export helpers from package `__init__` and from `youtube_downloader` for compatibility
- update imports in `cli_utils` and tests
- adjust tests to use new module

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68459fb348fc83218c05c160e8bc999e