### PR TITLE
Rename French identifiers

### DIFF
--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -22,12 +22,12 @@ def print_separator() -> None:
     print("*************************************************************")
 
 
-def ask_numeric_value(valeur_min: int, valeur_max: int, max_attempts: int = 3) -> int:
-    """Prompt the user to enter a number between ``valeur_min`` and ``valeur_max``.
+def ask_numeric_value(min_value: int, max_value: int, max_attempts: int = 3) -> int:
+    """Prompt the user to enter a number between ``min_value`` and ``max_value``.
 
     Args:
-        valeur_min: Minimum acceptable value.
-        valeur_max: Maximum acceptable value.
+        min_value: Minimum acceptable value.
+        max_value: Maximum acceptable value.
         max_attempts: Number of invalid attempts allowed before a
             :class:`ValidationError` is raised.
 
@@ -41,7 +41,7 @@ def ask_numeric_value(valeur_min: int, valeur_max: int, max_attempts: int = 3) -
     attempts = 0
     while True:
         v_str = input(
-            f"Donnez une valeur entre {valeur_min} et {valeur_max} : \n --> "
+            f"Donnez une valeur entre {min_value} et {max_value} : \n --> "
         )
         try:
             v_int = int(v_str)
@@ -52,9 +52,9 @@ def ask_numeric_value(valeur_min: int, valeur_max: int, max_attempts: int = 3) -
             if attempts >= max_attempts:
                 raise ValidationError("Nombre de tentatives dépassé")
             continue
-        if not (valeur_min <= v_int <= valeur_max):
+        if not (min_value <= v_int <= max_value):
             logger.warning(
-                f"FAIL : Vous devez rentrer un nombre (entre {valeur_min} et {valeur_max} )."
+                f"FAIL : Vous devez rentrer un nombre (entre {min_value} et {max_value} )."
             )
             logger.info("")
             attempts += 1
@@ -76,14 +76,14 @@ def display_main_menu() -> int:
     print()
     i = 0
     for items in CHOICE_MENU_ACCUEIL:
-        choix_menu = items
+        menu_choice = items
         i += 1
-        print(f"    {i} - {choix_menu}                              ")
+        print(f"    {i} - {menu_choice}                              ")
     print("                                                           ")
     print_separator()
-    valeur_choix_maximale = i
+    max_choice_value = i
 
-    return valeur_choix_maximale
+    return max_choice_value
 
 
 def ask_save_file_path(max_attempts: int = 3) -> Path:
@@ -189,43 +189,43 @@ def ask_youtube_link_file(max_attempts: int = 3) -> list[str]:
 
     attempts = 0
     while True:
-        link_url_video_youtube_final: list[str] = []
+        valid_urls: list[str] = []
         print()
         print()
         print_separator()
         print("*             Fichier contenant les urls Youtube            *")
         print_separator()
-        fichier_user = input("Indiquez le nom du fichier : \n --> ")
+        user_file = input("Indiquez le nom du fichier : \n --> ")
         print()
         try:
-            file_path = Path(fichier_user)
-            with file_path.open("r", encoding="utf-8") as fichier:
-                lignes = fichier.readlines()
-                compteur_ligne = 0
-                number_erreur = 0
-                number_links_file = len(lignes)
+            file_path = Path(user_file)
+            with file_path.open("r", encoding="utf-8") as f:
+                lines = f.readlines()
+                line_counter = 0
+                error_count = 0
+                total_links = len(lines)
 
-                if not number_links_file:
+                if not total_links:
                     logger.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
                     attempts += 1
                     if attempts >= max_attempts:
                         raise ValidationError("Aucune URL valide")
                     continue
 
-                for i in range(0, len(lignes)):
-                    url_video = lignes[i].strip()
-                    compteur_ligne += 1
+                for i in range(0, len(lines)):
+                    video_url = lines[i].strip()
+                    line_counter += 1
 
-                    if validate_youtube_url(url_video):
-                        link_url_video_youtube_final.append(url_video)
+                    if validate_youtube_url(video_url):
+                        valid_urls.append(video_url)
                     else:
                         logger.error("[ERREUR] : ")
                         logger.error("le prefixe attendu est : https://www.youtube.com/")
-                        logger.error(f"  le lien sur la ligne n° {compteur_ligne} ne sera pas télécharger")
+                        logger.error(f"  le lien sur la ligne n° {line_counter} ne sera pas télécharger")
                         logger.error("")
-                        number_erreur += 1
+                        error_count += 1
 
-                if number_erreur == number_links_file:
+                if error_count == total_links:
                     logger.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
                     attempts += 1
                     if attempts >= max_attempts:
@@ -239,7 +239,7 @@ def ask_youtube_link_file(max_attempts: int = 3) -> list[str]:
                 raise ValidationError("Fichier inaccessible")
             continue
 
-        return link_url_video_youtube_final
+        return valid_urls
 
 
 def ask_resolution_or_bitrate(
@@ -258,7 +258,7 @@ def ask_resolution_or_bitrate(
         The index (1-based) of the chosen stream in ``list_available_streams``.
     """
     i = 0
-    valeur_choix_maximale = i
+    max_choice_value = i
 
     if download_sound_only:
         print()
@@ -267,13 +267,13 @@ def ask_resolution_or_bitrate(
         print("*             Choississez la qualité audio                  *")
         print_separator()
         for stream in list_available_streams:
-            choix_menu = stream.abr  # Pour la qualité de l'audio
+            menu_choice = stream.abr  # Audio quality
             i += 1
-            print(f"      {i} - {choix_menu} ")
-            valeur_choix_maximale = i
+            print(f"      {i} - {menu_choice} ")
+            max_choice_value = i
 
         print_separator()
-        v_int = ask_numeric_value(1, valeur_choix_maximale)
+        v_int = ask_numeric_value(1, max_choice_value)
         return v_int
 
     print()
@@ -282,13 +282,13 @@ def ask_resolution_or_bitrate(
     print("*             Choississez la résolution vidéo               *")
     print_separator()
     for stream in list_available_streams:
-        choix_menu = stream.resolution  # pour la qualite de la vidéo
+        menu_choice = stream.resolution  # Video quality
         i += 1
-        print(f"      {i} - {choix_menu} ")
-        valeur_choix_maximale = i
+        print(f"      {i} - {menu_choice} ")
+        max_choice_value = i
 
     print_separator()
-    v_int = ask_numeric_value(1, valeur_choix_maximale)
+    v_int = ask_numeric_value(1, max_choice_value)
     return v_int
 
 

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -82,7 +82,7 @@ class YoutubeDownloader:
         self,
         stream: Any,
         save_path: Path,
-        url_video: str,
+        video_url: str,
         download_sound_only: bool,
     ) -> None:
         """Download ``stream`` to ``save_path`` with retries.
@@ -109,7 +109,7 @@ class YoutubeDownloader:
                 logger.info("")
                 if attempt == 2:
                     raise DownloadError(
-                        f"Echec du téléchargement pour {url_video}"
+                        f"Echec du téléchargement pour {video_url}"
                     ) from e
             except Exception as e:  # pragma: no cover - defensive
                 logger.exception("Unexpected error during download")
@@ -118,13 +118,13 @@ class YoutubeDownloader:
                 logger.info("")
                 if attempt == 2:
                     raise DownloadError(
-                        f"Echec du téléchargement pour {url_video}"
+                        f"Echec du téléchargement pour {video_url}"
                     ) from e
 
         if out_file and download_sound_only:
             self.conversion_mp4_in_mp3(out_file)
 
-    def streams_video(
+    def get_video_streams(
         self, download_sound_only: bool, youtube_video: YouTubeVideo
     ) -> Any:
         """Return the available streams for ``youtube_video``.
@@ -186,13 +186,13 @@ class YoutubeDownloader:
 
     def download_multiple_videos(
         self,
-        url_youtube_video_links: Iterable[str],
+        youtube_video_urls: Iterable[str],
         options: DownloadOptions,
     ) -> None:
         """Download one or more videos or audio tracks.
 
         Args:
-            url_youtube_video_links: Iterable of YouTube URLs to download.
+            youtube_video_urls: Iterable of YouTube URLs to download.
             options: Download behaviour configuration.
 
         Returns:
@@ -208,22 +208,22 @@ class YoutubeDownloader:
         choice_once = True
         choice_user = 1
 
-        url_list = list(url_youtube_video_links)
+        url_list = list(youtube_video_urls)
         if not url_list:
             logger.error("[ERREUR] : il y a aucune vidéo à télécharger")
             return None
 
-        for url_video in url_list:
-            youtube_video = self._create_youtube(url_video, progress_handler)
+        for video_url in url_list:
+            youtube_video = self._create_youtube(video_url, progress_handler)
             if youtube_video is None:
                 continue
 
             try:
-                streams = self.streams_video(download_sound_only, youtube_video)
+                streams = self.get_video_streams(download_sound_only, youtube_video)
             except StreamAccessError as e:
                 logger.error(
                     "[ERREUR] : Les flux pour la vidéo (%s) n'ont pas pu être récupérés. %s",
-                    url_video,
+                    video_url,
                     e,
                 )
                 continue
@@ -231,7 +231,7 @@ class YoutubeDownloader:
             if not streams:
                 logger.error(
                     "[ERREUR] : Aucun flux disponible pour la vidéo (%s).",
-                    url_video,
+                    video_url,
                 )
                 continue
 
@@ -240,7 +240,7 @@ class YoutubeDownloader:
             except KeyError as e:
                 logger.error(
                     "[ERREUR] : Impossible d'accéder au titre de la vidéo %s. Détail : %s",
-                    url_video,
+                    video_url,
                     e,
                 )
                 continue
@@ -280,7 +280,7 @@ class YoutubeDownloader:
             self._download_stream(
                 stream,
                 save_path,
-                url_video,
+                video_url,
                 download_sound_only,
             )
 

--- a/program_youtube_downloader/utils.py
+++ b/program_youtube_downloader/utils.py
@@ -17,20 +17,20 @@ def clear_screen() -> None:
         subprocess.run(["cmd", "/c", "cls"], check=True)
 
 
-def program_break_time(memorization_time: int, affichage_text: str) -> None:
+def program_break_time(memorization_time: int, message: str) -> None:
     """Display a short countdown.
 
     Args:
         memorization_time: Duration of the countdown in seconds.
-        affichage_text: Message displayed before the countdown number.
+        message: Message displayed before the countdown number.
     """
-    duree_restante_avant_lancement = memorization_time
+    remaining_seconds = memorization_time
     print(
-        f"{affichage_text} {memorization_time} secondes ",
+        f"{message} {memorization_time} secondes ",
         end="",
         flush=True,
     )
-    while duree_restante_avant_lancement > 0:
+    while remaining_seconds > 0:
         time.sleep(1)
-        print(f"{duree_restante_avant_lancement} ", end="", flush=True)
-        duree_restante_avant_lancement -= 1
+        print(f"{remaining_seconds} ", end="", flush=True)
+        remaining_seconds -= 1

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -171,7 +171,7 @@ def test_streams_video_http_error(monkeypatch):
     yt.streams.filter = filter_fail
     yd = YoutubeDownloader()
     with pytest.raises(StreamAccessError):
-        yd.streams_video(False, yt)
+        yd.get_video_streams(False, yt)
 
 
 def test_streams_video_success(monkeypatch):
@@ -192,7 +192,7 @@ def test_streams_video_success(monkeypatch):
     yt.streams = Chain()
     yd = YoutubeDownloader()
     # download_sound_only parameter is ignored but kept for API compatibility
-    assert yd.streams_video(False, yt) is result
+    assert yd.get_video_streams(False, yt) is result
 
 
 def test_conversion_mp4_in_mp3_rename_error(monkeypatch, tmp_path):
@@ -219,7 +219,7 @@ def test_download_multiple_videos_title_keyerror(monkeypatch, tmp_path):
             raise KeyError("missing")
 
     monkeypatch.setattr(
-        YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams
+        YoutubeDownloader, "get_video_streams", lambda self, dso, yt: yt.streams
     )
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
@@ -234,7 +234,7 @@ def test_download_multiple_videos_title_keyerror(monkeypatch, tmp_path):
 def test_download_multiple_videos_default_choice(monkeypatch, tmp_path):
     """When no callback is provided, the first stream is used."""
     monkeypatch.setattr(
-        YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams
+        YoutubeDownloader, "get_video_streams", lambda self, dso, yt: yt.streams
     )
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
@@ -258,7 +258,7 @@ def test_download_multiple_videos_download_error(monkeypatch, tmp_path):
             self.streams = DummyStreams([FailingStream()])
 
     monkeypatch.setattr(
-        YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams
+        YoutubeDownloader, "get_video_streams", lambda self, dso, yt: yt.streams
     )
     monkeypatch.setattr(builtins, "input", lambda *a, **k: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -94,7 +94,7 @@ def test_download_multiple_videos_custom_callbacks(monkeypatch, tmp_path: Path) 
         created['yt'] = yt
         return yt
 
-    monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
+    monkeypatch.setattr(YoutubeDownloader, "get_video_streams", lambda self, dso, yt: yt.streams)
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
     monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
@@ -151,7 +151,7 @@ def test_download_multiple_videos_no_streams(monkeypatch, tmp_path: Path) -> Non
     def fake_constructor(url: str) -> DummyYT:
         return DummyYT(url)
 
-    monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: [])
+    monkeypatch.setattr(YoutubeDownloader, "get_video_streams", lambda self, dso, yt: [])
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
     monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
@@ -237,7 +237,7 @@ def test_download_multiple_videos_download_error(monkeypatch, tmp_path: Path) ->
     def fake_constructor(url: str) -> DummyYT:
         return FailYT(url)
 
-    monkeypatch.setattr(YoutubeDownloader, "streams_video", lambda self, dso, yt: yt.streams)
+    monkeypatch.setattr(YoutubeDownloader, "get_video_streams", lambda self, dso, yt: yt.streams)
     monkeypatch.setattr("builtins.input", lambda *args, **kwargs: "")
     monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
     monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- translate parameter/variable names in cli utilities to English
- switch countdown helper to `message` and `remaining_seconds`
- rename download helpers in downloader
- adjust tests for renamed helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a1739f5c8321a62dfbad1e7c801d