### PR TITLE
Add stricter URL validation

### DIFF
--- a/program_youtube_downloader/validators.py
+++ b/program_youtube_downloader/validators.py
@@ -1,8 +1,20 @@
-from urllib.parse import urlparse
+import re
+
+
+_VIDEO_RE = re.compile(
+    r"^https?://(?:www\.)?"
+    r"(?:(?:[\w-]+\.)?youtube\.com/watch\?(?:[^\s]*\bv=[\w-]+)(?:[^\s]*\blist=[\w-]+)?"
+    r"|youtu\.be/[\w-]+(?:\?list=[\w-]+)?)",
+    re.IGNORECASE,
+)
 
 
 def validate_youtube_url(url: str) -> bool:
-    """Check whether ``url`` is a valid YouTube address.
+    """Check whether ``url`` points to a YouTube video.
+
+    The link must use HTTP(S) and either contain a ``v=`` parameter or use the
+    short ``youtu.be/<id>`` form. A ``list`` query parameter is also accepted
+    when present.
 
     Args:
         url: URL provided by the user.
@@ -12,15 +24,6 @@ def validate_youtube_url(url: str) -> bool:
     """
     if not url:
         return False
-    url = url.strip()
 
-    parsed = urlparse(url)
-    if parsed.scheme not in {"http", "https"}:
-        return False
-    host = parsed.netloc.lower()
-    if host == "youtu.be":
-        return True
-    if host.endswith("youtube.com"):
-        return True
-    return False
+    return bool(_VIDEO_RE.match(url.strip()))
 

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -13,10 +13,13 @@ def test_ask_numeric_value_retries(monkeypatch):
 
 
 def test_ask_youtube_url_normalizes_channel(monkeypatch):
-    inputs = iter(["https://www.youtube.com/@MyChannel"])
+    inputs = iter([
+        "https://www.youtube.com/@MyChannel",
+        "https://www.youtube.com/watch?v=good",
+    ])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
     url = cli_utils.ask_youtube_url()
-    assert url == "https://www.youtube.com/c/MyChannel"
+    assert url == "https://www.youtube.com/watch?v=good"
 
 
 def test_ask_youtube_url_invalid_prefix(monkeypatch):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -5,9 +5,14 @@ def test_validate_youtube_url_valid() -> None:
     assert validate_youtube_url("https://www.youtube.com/watch?v=ok")
     assert validate_youtube_url("https://youtube.com/watch?v=ok")
     assert validate_youtube_url("https://youtu.be/abc")
+    assert validate_youtube_url("https://www.youtube.com/watch?v=ok&list=123")
+    assert validate_youtube_url("https://youtu.be/abc?list=xyz")
 
 
 def test_validate_youtube_url_invalid() -> None:
     assert not validate_youtube_url("http://example.com")
     assert not validate_youtube_url("notaurl")
     assert not validate_youtube_url("ftp://youtu.be/id")
+    assert not validate_youtube_url("https://www.youtube.com/watch?list=only")
+    assert not validate_youtube_url("https://youtu.be/")
+    assert not validate_youtube_url("https://www.youtube.com/playlist?list=abc")


### PR DESCRIPTION
## Summary
- validate_youtube_url now checks for explicit video identifiers using regex
- document the behaviour
- test new valid and invalid URL patterns
- adjust CLI tests for the stricter validator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845a36900f08321b1403a94b2c096f4