### PR TITLE
Fix path references for main.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,7 @@ Chaque agent regroupe des fonctions et responsabilités associées.
 ## Agent CLI
 **Rôle** : Fournir l'interface en ligne de commande et dispatcher les choix de l'utilisateur.**
 
-**Points d'entrée** :
-- `main()` dans [main.py](main.py) pour le lancement général.
+- `main()` dans [program_youtube_downloader/main.py](program_youtube_downloader/main.py) pour le lancement général.
 - Classe `CLI` dans [program_youtube_downloader/cli.py](program_youtube_downloader/cli.py) pour la gestion du menu et des sous-commandes.
 
 **Entrées** : arguments de la ligne de commande ou sélections depuis le menu.
@@ -20,7 +19,7 @@ Chaque agent regroupe des fonctions et responsabilités associées.
 
 Utilisation :
 ```python
-from main import main
+from program_youtube_downloader.main import main
 main()
 ```
 
@@ -121,7 +120,7 @@ value = ask_numeric_value(1, 3)
 
 | Agent | Fichier(s) | Fonctions principales |
 |-------|------------|----------------------|
-| Agent CLI | `main.py`, `program_youtube_downloader/cli.py` | `main()`, classe `CLI` |
+| Agent CLI | `program_youtube_downloader/main.py`, `program_youtube_downloader/cli.py` | `main()`, classe `CLI` |
 | Agent de téléchargement | `downloader.py` | `download_multiple_videos` |
 | Agent de conversion | `downloader.py` | `conversion_mp4_in_mp3` |
 | Agent de progression | `program_youtube_downloader/progress.py` | `on_download_progress`, `progress_bar` |

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Un menu s’affichera pour choisir le type de téléchargement (vidéo ou audio,
 Pour générer une version autonome du programme vous pouvez utiliser `pyinstaller` :
 
 ```bash
-pyinstaller --onefile --add-data "mypy.ini;." --hidden-import "youtube_downloader" main.py
+pyinstaller --onefile --add-data "mypy.ini;." --hidden-import "youtube_downloader" program_youtube_downloader/main.py
 ```
 
 ## Aperçu
@@ -110,7 +110,7 @@ Image :
 
 ## Structure du projet
 
-- `main.py` : point d’entrée du programme contenant la boucle de menu.
+- `program_youtube_downloader/main.py` : point d’entrée du programme contenant la boucle de menu.
 - `downloader.py` : logique principale de téléchargement et conversions.
 - `cli_utils.py` : fonctions d'interaction utilisateur et gestion des menus.
 - `constants.py` : libellés du menu et URL de base communes.
@@ -150,6 +150,7 @@ consultez [AGENTS.md](AGENTS.md) à la racine du dépôt.
 ## Documentation
 
 - [docs/index.md](docs/index.md)
+- [docs/project-overview.md](docs/project-overview.md)
 - [docs/guides/](docs/guides/)
 - [docs/releases/](docs/releases/)
 - [docs/reference/api-reference.md](docs/reference/api-reference.md)

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -6,7 +6,7 @@ Ce document résume le fonctionnement global du projet **Program Youtube Downloa
 
 Le dépôt contient un outil en ligne de commande permettant de télécharger des vidéos ou l'audio depuis YouTube. La configuration du projet et l'installation des dépendances sont décrites dans `pyproject.toml`, qui déclare un script `program-youtube-downloader` exécutant `program_youtube_downloader.main:main`.
 
-Le README précise les fichiers clés et leur rôle : `main.py` pour la boucle de menu, `downloader.py` pour les téléchargements et conversions, `cli_utils.py` pour les interactions utilisateur, `constants.py` pour les messages du menu, `progress.py` pour la barre de progression, `validators.py` pour vérifier les URL, `config.py` pour l'objet `DownloadOptions`, et `youtube_downloader.py` pour des utilitaires divers.
+Le README précise les fichiers clés et leur rôle : `program_youtube_downloader/main.py` pour la boucle de menu, `downloader.py` pour les téléchargements et conversions, `cli_utils.py` pour les interactions utilisateur, `constants.py` pour les messages du menu, `progress.py` pour la barre de progression, `validators.py` pour vérifier les URL, `config.py` pour l'objet `DownloadOptions`, et `youtube_downloader.py` pour des utilitaires divers.
 
 ## Nouveautés
 
@@ -17,7 +17,7 @@ Le README précise les fichiers clés et leur rôle : `main.py` pour la boucle 
 
 Le fichier `AGENTS.md` décrit chaque *agent* (groupe de responsabilités) en indiquant son point d'entrée principal :
 
-- **Agent CLI** : `main()` dans `main.py` gère les arguments et lance une sous-commande ou un menu interactif.
+- **Agent CLI** : `main()` dans `program_youtube_downloader/main.py` gère les arguments et lance une sous-commande ou un menu interactif.
 - **Agent de téléchargement** : `download_multiple_videos()` dans `downloader.py` se charge d'obtenir les flux vidéo via `pytubefix` et de les enregistrer.
 - **Agent de conversion** : `conversion_mp4_in_mp3()` dans `downloader.py` renomme un fichier MP4 en MP3 et supprime l'original.
 - **Agent de progression** : `on_download_progress` et `progress_bar` dans `progress.py` pour l'affichage d'une barre de téléchargement.

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -2,7 +2,7 @@
 
 Cette section décrit brièvement les fonctions et classes disponibles dans le package `program_youtube_downloader`.
 
-## `main.py`
+## `program_youtube_downloader/main.py`
 - **`parse_args(argv=None)`** : analyse les arguments de la ligne de commande et retourne un objet `argparse.Namespace`.
 - **`menu()`** : lance le menu interactif (non couvert par les tests).
 - **`main(argv=None)`** : point d'entrée principal qui redirige vers les sous-commandes ou le menu.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -19,7 +19,7 @@ Le cœur de l’application se trouve dans le package `program_youtube_downloade
 
 ## Composants techniques
 
-- **`main.py`** : point d’entrée de la CLI et gestion des arguments.
+- **`program_youtube_downloader/main.py`** : point d’entrée de la CLI et gestion des arguments.
 - **`downloader.py`** : récupération des flux YouTube et sauvegarde des fichiers.
 - **`cli_utils.py`** : affichage des menus et validation des choix utilisateur.
 - **`progress.py`** : barre de progression pendant les téléchargements.

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -1,5 +1,5 @@
-# main.py
-# pyinstaller --onefile --add-data "mypy.ini;." --hidden-import "youtube_downloader" main.py
+# program_youtube_downloader/main.py
+# pyinstaller --onefile --add-data "mypy.ini;." --hidden-import "youtube_downloader" program_youtube_downloader/main.py
 import os
 import sys
 import argparse


### PR DESCRIPTION
## Summary
- update documentation with the full path to `main.py`
- update import example in `AGENTS.md`
- add a link to `docs/project-overview.md`
- adjust comments and pyinstaller command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fb55e0fc8321b0f8c967d2a371ae