### PR TITLE
Improve clear_screen error handling

### DIFF
--- a/program_youtube_downloader/utils.py
+++ b/program_youtube_downloader/utils.py
@@ -5,16 +5,23 @@ from __future__ import annotations
 import os
 import subprocess
 import time
+import logging
 
 __all__ = ["clear_screen", "program_break_time"]
+
+logger = logging.getLogger(__name__)
 
 
 def clear_screen() -> None:
     """Clear the terminal screen on Windows or POSIX systems."""
-    if os.name == "posix":
-        subprocess.run(["clear"], check=True)
-    else:
-        subprocess.run(["cmd", "/c", "cls"], check=True)
+    try:
+        if os.name == "posix":
+            subprocess.run(["clear"], check=True)
+        else:
+            subprocess.run(["cmd", "/c", "cls"], check=True)
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - failure path
+        logger.warning("Failed to clear screen: %s", exc)
+        return
 
 
 def program_break_time(memorization_time: int, message: str) -> None:

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from urllib.error import HTTPError
 import logging
+import subprocess
 
 import pytest
 
@@ -165,6 +166,18 @@ def test_clear_screen(monkeypatch):
     assert called.get("check") is True
     if os.name != "posix":
         assert "shell" not in called
+
+
+def test_clear_screen_error(monkeypatch, caplog):
+    """Failure of subprocess.run should be caught and logged."""
+
+    def fail_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args[0])
+
+    monkeypatch.setattr(utils.subprocess, "run", fail_run)
+    with caplog.at_level(logging.WARNING):
+        utils.clear_screen()
+    assert "Failed to clear screen" in caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- log warnings when `clear_screen` fails
- unit test to ensure subprocess errors don't bubble up

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470d7d8074832197c663f7e0bd39bd