### PR TITLE
Ensure strict YouTube URL validation

### DIFF
--- a/program_youtube_downloader/validators.py
+++ b/program_youtube_downloader/validators.py
@@ -6,7 +6,7 @@ from .exceptions import InvalidURLError
 _VIDEO_RE = re.compile(
     r"^https?://(?:www\.)?"
     r"(?:(?:[\w-]+\.)?youtube\.com/watch\?(?:[^\s]*\bv=[\w-]+)(?:[^\s]*\blist=[\w-]+)?"
-    r"|youtu\.be/[\w-]+(?:\?list=[\w-]+)?)",
+    r"|youtu\.be/[\w-]+(?:\?list=[\w-]+)?)$",
     re.IGNORECASE,
 )
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -25,3 +25,10 @@ def test_validate_youtube_url_invalid() -> None:
         validate_youtube_url("https://youtu.be/")
     with pytest.raises(InvalidURLError):
         validate_youtube_url("https://www.youtube.com/playlist?list=abc")
+
+
+def test_validate_youtube_url_rejects_extra_chars() -> None:
+    with pytest.raises(InvalidURLError):
+        validate_youtube_url("https://www.youtube.com/watch?v=ok extra")
+    with pytest.raises(InvalidURLError):
+        validate_youtube_url("https://youtu.be/abc extra")


### PR DESCRIPTION
## Summary
- anchor the video URL regex so no extra characters are allowed
- check a couple of malformed URLs in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684715bb32948321881fed7e424f96d9