### PR TITLE
Ensure end message only on successful downloads

### DIFF
--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -302,8 +302,9 @@ class YoutubeDownloader:
                 logger.exception("Unexpected error in downloader thread")
                 errors.append(url)
 
-        cli_utils.print_end_download_message()
-        if errors:
+        if not errors:
+            cli_utils.print_end_download_message()
+        else:
             logger.error(
                 "[ERREUR] : Les téléchargements suivants ont échoué : %s",
                 ", ".join(errors),


### PR DESCRIPTION
## Summary
- print the end of download message only when all downloads succeed
- test that the end message is skipped on failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68471784b85c832188e3d58a3db39dd6