### PR TITLE
Validate max_workers input

### DIFF
--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -294,6 +294,9 @@ class YoutubeDownloader:
         Returns:
             ``None``. The method does not report which URLs failed to
             download.
+
+        Raises:
+            ValueError: If ``options.max_workers`` is less than 1.
         """
 
         download_sound_only = options.download_sound_only
@@ -308,6 +311,9 @@ class YoutubeDownloader:
         if not url_list:
             logger.error("[ERREUR] : il y a aucune vidéo à télécharger")
             return None
+
+        if options.max_workers < 1:
+            raise ValueError("max_workers must be >= 1")
 
         futures: dict[Any, str] = {}
         with ThreadPoolExecutor(max_workers=options.max_workers) as executor:

--- a/tests/test_parallel_downloads.py
+++ b/tests/test_parallel_downloads.py
@@ -108,3 +108,11 @@ def test_end_message_skipped_on_error(monkeypatch, tmp_path: Path):
     yd.download_multiple_videos(urls, options)
 
     assert "printed" not in called
+
+
+def test_invalid_max_workers(tmp_path: Path) -> None:
+    """max_workers < 1 should raise an error."""
+    yd = YoutubeDownloader(youtube_cls=fake_constructor)
+    options = DownloadOptions(save_path=tmp_path, max_workers=0)
+    with pytest.raises(ValueError):
+        yd.download_multiple_videos(["https://youtu.be/a"], options)


### PR DESCRIPTION
## Summary
- check `max_workers` before using ThreadPoolExecutor
- document potential ValueError in downloader API
- test invalid worker counts are rejected

## Testing
- `pytest tests/test_parallel_downloads.py::test_invalid_max_workers -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684721facd288321baa075530faf2941