### PR TITLE
Refactor download helpers

### DIFF
--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -68,7 +68,7 @@ class YoutubeDownloader:
             logger.error("[ERREUR] : Connexion à la vidéo impossible : %s", e)
             return None
 
-    def _choose_stream(
+    def _select_stream(
         self,
         download_sound_only: bool,
         streams: Any,
@@ -80,7 +80,7 @@ class YoutubeDownloader:
             return callback(download_sound_only, streams)
         return 1
 
-    def _download_stream(
+    def _download_video(
         self,
         stream: Any,
         save_path: Path,
@@ -186,7 +186,7 @@ class YoutubeDownloader:
                 file_path.unlink()
             logger.info("")
 
-    def _process_url(
+    def _prepare_video(
         self,
         video_url: str,
         download_sound_only: bool,
@@ -249,7 +249,7 @@ class YoutubeDownloader:
         """Schedule ``stream`` for download using ``executor``."""
 
         future = executor.submit(
-            self._download_stream,
+            self._download_video,
             stream,
             save_path,
             video_url,
@@ -318,7 +318,7 @@ class YoutubeDownloader:
         futures: dict[Any, str] = {}
         with ThreadPoolExecutor(max_workers=options.max_workers) as executor:
             for video_url in url_list:
-                processed = self._process_url(
+                processed = self._prepare_video(
                     video_url,
                     download_sound_only,
                     progress_handler,
@@ -329,7 +329,7 @@ class YoutubeDownloader:
                 streams, youtube_video, video_title = processed
 
                 if choice_once:
-                    choice_user = self._choose_stream(
+                    choice_user = self._select_stream(
                         download_sound_only,
                         streams,
                         choice_callback,

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -63,7 +63,7 @@ def test_create_youtube_registers_progress(monkeypatch) -> None:
     assert created['yt'].progress.__self__ is progress
 
 
-def test_choose_stream_uses_callback() -> None:
+def test_select_stream_uses_callback() -> None:
     called = {}
 
     def cb(sound_only: bool, streams: list[int]) -> int:
@@ -71,13 +71,13 @@ def test_choose_stream_uses_callback() -> None:
         return 2
 
     yd = YoutubeDownloader()
-    result = yd._choose_stream(True, [1, 2], cb)
+    result = yd._select_stream(True, [1, 2], cb)
 
     assert result == 2
     assert called['args'] == (True, [1, 2])
 
 
-def test_download_stream_error(monkeypatch, tmp_path: Path) -> None:
+def test_download_video_error(monkeypatch, tmp_path: Path) -> None:
     class FailStream(DummyStream):
         def download(self, output_path: str) -> str:
             raise OSError("boom")
@@ -86,17 +86,17 @@ def test_download_stream_error(monkeypatch, tmp_path: Path) -> None:
     yd = YoutubeDownloader()
 
     with pytest.raises(DownloadError):
-        yd._download_stream(stream, tmp_path, "https://youtu.be/fail", False)
+        yd._download_video(stream, tmp_path, "https://youtu.be/fail", False)
 
 
-def test_process_url_success(monkeypatch) -> None:
+def test_prepare_video_success(monkeypatch) -> None:
     monkeypatch.setattr(
         YoutubeDownloader, "get_video_streams", lambda self, dso, yt: yt.streams
     )
     progress = DummyHandler()
     yd = YoutubeDownloader(progress_handler=progress, youtube_cls=lambda u: DummyYT(u))
 
-    result = yd._process_url("https://youtu.be/x", False, progress)
+    result = yd._prepare_video("https://youtu.be/x", False, progress)
 
     assert result is not None
     streams, yt, title = result
@@ -112,7 +112,7 @@ def test_submit_download(monkeypatch, tmp_path: Path) -> None:
         called["args"] = (stream, path, url, sound_only)
 
     yd = YoutubeDownloader()
-    monkeypatch.setattr(yd, "_download_stream", fake_download)
+    monkeypatch.setattr(yd, "_download_video", fake_download)
 
     class DummyExecutor:
         def __init__(self) -> None:

--- a/tests/test_parallel_downloads.py
+++ b/tests/test_parallel_downloads.py
@@ -71,7 +71,7 @@ def test_parallel_error_collection(monkeypatch, tmp_path: Path, caplog):
             raise DownloadError("boom")
         Path(path / stream.default_filename).write_text("ok")
 
-    monkeypatch.setattr(YoutubeDownloader, "_download_stream", failing)
+    monkeypatch.setattr(YoutubeDownloader, "_download_video", failing)
     yd = YoutubeDownloader(youtube_cls=fake_constructor)
     options = DownloadOptions(save_path=tmp_path, max_workers=2)
     urls = ["https://youtu.be/a", "https://youtu.be/b"]
@@ -92,7 +92,7 @@ def test_end_message_skipped_on_error(monkeypatch, tmp_path: Path):
             raise DownloadError("boom")
         Path(path / stream.default_filename).write_text("ok")
 
-    monkeypatch.setattr(YoutubeDownloader, "_download_stream", failing)
+    monkeypatch.setattr(YoutubeDownloader, "_download_video", failing)
 
     called = {}
 


### PR DESCRIPTION
## Summary
- introduce `_prepare_video`, `_select_stream` and `_download_video`
- adjust `download_multiple_videos` to use helper functions
- update tests for new helper APIs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472bcead5c8321a124c91e2a84f726