### PR TITLE
Prevent mp3 overwrite during conversion

### DIFF
--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -176,6 +176,17 @@ class YoutubeDownloader:
         file_path = Path(file_downloaded)
         try:
             new_file = file_path.with_suffix(".mp3")
+            if new_file.exists():
+                counter = 1
+                candidate = new_file.with_name(
+                    f"{new_file.stem}_{counter}{new_file.suffix}"
+                )
+                while candidate.exists():
+                    counter += 1
+                    candidate = new_file.with_name(
+                        f"{new_file.stem}_{counter}{new_file.suffix}"
+                    )
+                new_file = candidate
             file_path.rename(new_file)
             if file_path.exists():
                 file_path.unlink()

--- a/tests/test_youtube_downloader.py
+++ b/tests/test_youtube_downloader.py
@@ -14,3 +14,21 @@ def test_conversion_mp4_in_mp3(tmp_path: Path) -> None:
     mp3_path = tmp_path / "sample.mp3"
     assert mp3_path.exists()
     assert mp3_path.read_text() == "dummy-data"
+
+
+def test_conversion_mp4_in_mp3_overwrite(tmp_path: Path) -> None:
+    mp4_path = tmp_path / "sample.mp4"
+    mp4_path.write_text("dummy-data")
+
+    # create existing mp3 to trigger unique naming
+    existing = tmp_path / "sample.mp3"
+    existing.write_text("old")
+
+    yd = YoutubeDownloader()
+    yd.conversion_mp4_in_mp3(mp4_path)
+
+    assert existing.exists()
+    mp3_new = tmp_path / "sample_1.mp3"
+    assert mp3_new.exists()
+    assert mp3_new.read_text() == "dummy-data"
+    assert not mp4_path.exists()


### PR DESCRIPTION
## Summary
- avoid overwriting an existing MP3 when converting
- test conversion when destination already exists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68472d8af9d48321b387948839eae25a