### PR TITLE
Add playlist/channel loader helpers

### DIFF
--- a/program_youtube_downloader/cli.py
+++ b/program_youtube_downloader/cli.py
@@ -65,31 +65,42 @@ class CLI:
         options = self.create_download_options(audio_only)
         self.downloader.download_multiple_videos(urls, options)
 
-    def handle_playlist_option(self, audio_only: bool) -> None:
-        """Download an entire playlist."""
-        url = cli_utils.ask_youtube_url()
+    # ------------------------------------------------------------------
+    # Loader helpers
+    # ------------------------------------------------------------------
+    def load_playlist(self, url: str) -> Playlist:
+        """Return a :class:`Playlist` instance for ``url`` or raise an error."""
         try:
-            playlist = Playlist(url)
+            return Playlist(url)
         except (PytubeError, KeyError, ValueError) as e:
             logger.exception("Error connecting to playlist")
             raise PlaylistConnectionError("Connexion à la Playlist impossible") from e
         except Exception:
             logger.exception("Unexpected error while connecting to playlist")
             raise
-        options = self.create_download_options(audio_only)
-        self.downloader.download_multiple_videos(playlist, options)  # type: ignore
 
-    def handle_channel_option(self, audio_only: bool) -> None:
-        """Download all videos from a channel."""
-        url = cli_utils.ask_youtube_url()
+    def load_channel(self, url: str) -> Channel:
+        """Return a :class:`Channel` instance for ``url`` or raise an error."""
         try:
-            channel = Channel(url)
+            return Channel(url)
         except (PytubeError, KeyError, ValueError) as e:
             logger.exception("Error connecting to channel")
             raise ChannelConnectionError("Connexion à la chaîne Youtube impossible") from e
         except Exception:
             logger.exception("Unexpected error while connecting to channel")
             raise
+
+    def handle_playlist_option(self, audio_only: bool) -> None:
+        """Download an entire playlist."""
+        url = cli_utils.ask_youtube_url()
+        playlist = self.load_playlist(url)
+        options = self.create_download_options(audio_only)
+        self.downloader.download_multiple_videos(playlist, options)  # type: ignore
+
+    def handle_channel_option(self, audio_only: bool) -> None:
+        """Download all videos from a channel."""
+        url = cli_utils.ask_youtube_url()
+        channel = self.load_channel(url)
         options = self.create_download_options(audio_only)
         self.downloader.download_multiple_videos(channel, options)  # type: ignore
 

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -5,16 +5,11 @@ import sys
 import argparse
 import logging
 from pathlib import Path
-from pytube import Playlist, Channel
 
-
-from pytube.exceptions import PytubeError
 from . import cli_utils
 from .downloader import YoutubeDownloader
-from .exceptions import PlaylistConnectionError, ChannelConnectionError
-from .config import DownloadOptions
-from .constants import MenuOption
 from .cli import CLI
+from .config import DownloadOptions
 
 logger = logging.getLogger(__name__)
 
@@ -145,26 +140,14 @@ def main(
             options,
         )
     elif command == "playlist":
-        try:
-            playlist = Playlist(args.url)
-        except (PytubeError, KeyError, ValueError) as e:
-            raise PlaylistConnectionError("Connexion à la Playlist impossible") from e
-        except Exception:
-            logger.exception("Unexpected error while connecting to playlist")
-            raise
+        playlist = cli.load_playlist(args.url)
         options = create_download_options(cli, args.audio, args.output_dir)
         yd.download_multiple_videos(
             playlist,
             options,
         )  # type: ignore
     elif command == "channel":
-        try:
-            channel = Channel(args.url)
-        except (PytubeError, KeyError, ValueError) as e:
-            raise ChannelConnectionError("Connexion à la chaîne Youtube impossible") from e
-        except Exception:
-            logger.exception("Unexpected error while connecting to channel")
-            raise
+        channel = cli.load_channel(args.url)
         options = create_download_options(cli, args.audio, args.output_dir)
         yd.download_multiple_videos(
             channel,

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -178,7 +178,7 @@ def test_main_video_command(monkeypatch, tmp_path):
 def test_main_playlist_command(monkeypatch, tmp_path):
     dd = DummyDownloader()
     monkeypatch.setattr(
-        main_module, "Playlist", lambda u: ["https://youtu.be/1"]
+        main_module.CLI, "load_playlist", lambda self, u: ["https://youtu.be/1"]
     )
     monkeypatch.setattr(
         main_module.cli_utils, "ask_save_file_path", lambda: tmp_path
@@ -196,7 +196,7 @@ def test_main_playlist_command(monkeypatch, tmp_path):
 def test_main_channel_command(monkeypatch, tmp_path):
     dd = DummyDownloader()
     monkeypatch.setattr(
-        main_module, "Channel", lambda u: ["https://youtu.be/2"]
+        main_module.CLI, "load_channel", lambda self, u: ["https://youtu.be/2"]
     )
     monkeypatch.setattr(
         main_module.cli_utils, "ask_save_file_path", lambda: tmp_path

--- a/tests/test_menu_handlers.py
+++ b/tests/test_menu_handlers.py
@@ -36,7 +36,7 @@ def test_handle_videos_option(monkeypatch, tmp_path):
 def test_handle_playlist_option(monkeypatch, tmp_path):
     dd = DummyDownloader()
     monkeypatch.setattr(cli_module.cli_utils, "ask_youtube_url", lambda: "https://youtube.com/playlist")
-    monkeypatch.setattr(cli_module, "Playlist", lambda url: ["v1"])
+    monkeypatch.setattr(cli_module.CLI, "load_playlist", lambda self, url: ["v1"])
     monkeypatch.setattr(cli_module.CLI, "create_download_options", lambda self, ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
     cli = cli_module.CLI(dd)
     cli.handle_playlist_option(True)
@@ -47,7 +47,7 @@ def test_handle_playlist_option(monkeypatch, tmp_path):
 def test_handle_playlist_option_error(monkeypatch):
     dd = DummyDownloader()
     monkeypatch.setattr(cli_module.cli_utils, "ask_youtube_url", lambda: "https://youtube.com/playlist")
-    monkeypatch.setattr(cli_module, "Playlist", lambda url: (_ for _ in ()).throw(ValueError()))
+    monkeypatch.setattr(cli_module.CLI, "load_playlist", lambda self, url: (_ for _ in ()).throw(cli_module.PlaylistConnectionError()))
     with pytest.raises(cli_module.PlaylistConnectionError):
         cli_module.CLI(dd).handle_playlist_option(False)
 
@@ -55,6 +55,6 @@ def test_handle_playlist_option_error(monkeypatch):
 def test_handle_channel_option_error(monkeypatch):
     dd = DummyDownloader()
     monkeypatch.setattr(cli_module.cli_utils, "ask_youtube_url", lambda: "https://youtube.com/channel")
-    monkeypatch.setattr(cli_module, "Channel", lambda url: (_ for _ in ()).throw(ValueError()))
+    monkeypatch.setattr(cli_module.CLI, "load_channel", lambda self, url: (_ for _ in ()).throw(cli_module.ChannelConnectionError()))
     with pytest.raises(cli_module.ChannelConnectionError):
         cli_module.CLI(dd).handle_channel_option(False)


### PR DESCRIPTION
## Summary
- centralize Playlist and Channel initialization in CLI
- adjust main entrypoint to call new helpers
- update unit tests for new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473675e8688321aa4f835d56d270b4