### PR TITLE
Add PYDL_MAX_WORKERS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,13 @@ Vous pouvez également passer le dossier de destination directement avec
 program-youtube-downloader video https://youtu.be/example --output-dir /chemin/de/sortie
 ```
 
+Vous pouvez également contrôler le nombre de téléchargements parallèles
+en définissant la variable d'environnement `PYDL_MAX_WORKERS` :
+
+```bash
+PYDL_MAX_WORKERS=4 program-youtube-downloader video https://youtu.be/example
+```
+
 ## Tests
 
 Les tests unitaires sont écrits avec `pytest`. Après l’installation des dépendances, exécutez :

--- a/program_youtube_downloader/config.py
+++ b/program_youtube_downloader/config.py
@@ -1,8 +1,19 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional, Callable, Any
+import os
 
 from .progress import ProgressHandler
+
+
+def _max_workers_from_env() -> int:
+    value = os.getenv("PYDL_MAX_WORKERS")
+    if value is None:
+        return 1
+    try:
+        return int(value)
+    except ValueError:
+        return 1
 
 
 @dataclass
@@ -20,11 +31,12 @@ class DownloadOptions:
         progress_handler: Object receiving progress events from ``pytubefix``.
             Defaults to :class:`~program_youtube_downloader.progress.ProgressBarHandler`.
         max_workers: Number of simultaneous downloads. ``1`` disables
-            threading.
+            threading. If not provided, the value is read from the
+            ``PYDL_MAX_WORKERS`` environment variable, defaulting to ``1``.
     """
 
     save_path: Optional[Path] = None
     download_sound_only: bool = False
     choice_callback: Optional[Callable[[bool, Any], int]] = None
     progress_handler: Optional[ProgressHandler] = None
-    max_workers: int = 1
+    max_workers: int = field(default_factory=_max_workers_from_env)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+from program_youtube_downloader.config import DownloadOptions
+
+
+def test_max_workers_env(monkeypatch):
+    monkeypatch.setenv("PYDL_MAX_WORKERS", "3")
+    opts = DownloadOptions()
+    assert opts.max_workers == 3
+
+
+def test_max_workers_env_invalid(monkeypatch):
+    monkeypatch.setenv("PYDL_MAX_WORKERS", "foo")
+    opts = DownloadOptions()
+    assert opts.max_workers == 1
+
+
+def test_max_workers_env_default(monkeypatch):
+    monkeypatch.delenv("PYDL_MAX_WORKERS", raising=False)
+    opts = DownloadOptions()
+    assert opts.max_workers == 1


### PR DESCRIPTION
## Summary
- read max worker count from `PYDL_MAX_WORKERS`
- document the environment variable
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473ce4bbf08321904c7b7868b72d11