### PR TITLE
Add PydlError base exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,7 @@ value = ask_numeric_value(1, 3)
 **Point d'entrée** : [program_youtube_downloader/exceptions.py](program_youtube_downloader/exceptions.py)
 
 **Exceptions principales** :
+- `PydlError` comme classe de base commune.
 - `DownloadError`, `ValidationError` pour les erreurs génériques.
 - `PlaylistConnectionError`, `ChannelConnectionError` pour les problèmes d'accès.
 - `StreamAccessError`, `DirectoryCreationError`, `InvalidURLError` pour les cas particuliers.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Image :
 - `validators.py` : vérifications des liens YouTube fournis par l'utilisateur.
 - `config.py` : objet `DownloadOptions` pour paramétrer les téléchargements.
 - `youtube_downloader.py` : utilitaires généraux (effacement d'écran, compte à rebours).
-- `exceptions.py` : définitions des exceptions `DownloadError` et `ValidationError`.
+- `exceptions.py` : définit la base `PydlError` et toutes les exceptions
+  dérivées (`DownloadError`, `ValidationError`, etc.).
 - `requirements.txt` : liste des dépendances Python nécessaires.
 - `mypy.ini` : configuration minimale pour `mypy`.
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -50,6 +50,7 @@ Ces éléments composent l'API interne du projet et sont utilisés par la CLI ai
 - `YouTubeVideo` : protocole minimal pour représenter un objet `YouTube`.
 
 ## `exceptions.py`
+- `PydlError` : classe de base pour toutes les erreurs personnalisées.
 - `DownloadError` : échec répété lors du téléchargement d'un flux.
 - `ValidationError` : validation utilisateur impossible après plusieurs essais.
 - `PlaylistConnectionError` : connexion à une playlist YouTube impossible.

--- a/program_youtube_downloader/__init__.py
+++ b/program_youtube_downloader/__init__.py
@@ -1,8 +1,9 @@
 """Public exports for program_youtube_downloader."""
-from .exceptions import DownloadError, ValidationError
+from .exceptions import PydlError, DownloadError, ValidationError
 from .utils import clear_screen, program_break_time
 
 __all__ = [
+    "PydlError",
     "DownloadError",
     "ValidationError",
     "clear_screen",

--- a/program_youtube_downloader/exceptions.py
+++ b/program_youtube_downloader/exceptions.py
@@ -1,27 +1,31 @@
-class DownloadError(Exception):
+class PydlError(Exception):
+    """Base class for all custom errors."""
+
+
+class DownloadError(PydlError):
     """Raised when a download fails after several retries."""
 
 
-class ValidationError(Exception):
+class ValidationError(PydlError):
     """Raised when user input validation repeatedly fails."""
 
 
-class PlaylistConnectionError(Exception):
+class PlaylistConnectionError(PydlError):
     """Raised when connecting to a playlist fails."""
 
 
-class ChannelConnectionError(Exception):
+class ChannelConnectionError(PydlError):
     """Raised when connecting to a channel fails."""
 
 
-class StreamAccessError(Exception):
+class StreamAccessError(PydlError):
     """Raised when accessing the streams of a video fails."""
 
 
-class DirectoryCreationError(Exception):
+class DirectoryCreationError(PydlError):
     """Raised when a destination directory cannot be created."""
 
 
-class InvalidURLError(Exception):
+class InvalidURLError(PydlError):
     """Raised when a provided URL does not match expected YouTube patterns."""
 


### PR DESCRIPTION
## Summary
- introduce `PydlError` base class for all custom exceptions
- update imports and exports to use new base
- document new hierarchy in README, AGENTS.md and API reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684743a227588321948a83aa9ca031a7