### PR TITLE
Add __all__ exports for each module

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -10,7 +10,7 @@ Cette section décrit brièvement les fonctions et classes disponibles dans le p
 
 ## `downloader.py`
 - **`YoutubeDownloader`** : classe principale gérant le téléchargement.
-  - `streams_video(download_sound_only, youtube_video)` : retourne les flux disponibles pour une vidéo.
+  - `get_video_streams(download_sound_only, youtube_video)` : retourne les flux disponibles pour une vidéo.
   - `conversion_mp4_in_mp3(path)` : convertit un fichier MP4 en MP3 et supprime l'original.
   - `download_multiple_videos(urls, options)` : télécharge une liste d'URL ou de ressources YouTube.
 

--- a/docs/reference/tests-overview.md
+++ b/docs/reference/tests-overview.md
@@ -18,7 +18,7 @@ Ce document résume les tests unitaires situés dans le dossier `tests/`. Chaque
 
     Fonctions d’aide – teste `program_break_time` et `clear_screen`.
 
-    Comportement du téléchargeur – teste `streams_video`, `conversion_mp4_in_mp3`
+    Comportement du téléchargeur – teste `get_video_streams`, `conversion_mp4_in_mp3`
     et certaines parties de `download_multiple_videos`, y compris les scénarios d’erreur.
 ```
 

--- a/program_youtube_downloader/cli.py
+++ b/program_youtube_downloader/cli.py
@@ -139,3 +139,6 @@ class CLI:
 
             # end match
         # end while
+
+
+__all__ = ["CLI"]

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -308,3 +308,16 @@ def pause_return_to_menu() -> None:
     input("Appuyer sur ENTREE pour revenir au menu d'accueil")
     program_break_time(3, "Le menu d'accueil va revenir dans")
     clear_screen()
+
+
+__all__ = [
+    "print_separator",
+    "ask_numeric_value",
+    "display_main_menu",
+    "ask_save_file_path",
+    "ask_youtube_url",
+    "ask_youtube_link_file",
+    "ask_resolution_or_bitrate",
+    "print_end_download_message",
+    "pause_return_to_menu",
+]

--- a/program_youtube_downloader/config.py
+++ b/program_youtube_downloader/config.py
@@ -40,3 +40,6 @@ class DownloadOptions:
     choice_callback: Optional[Callable[[bool, Any], int]] = None
     progress_handler: Optional[ProgressHandler] = None
     max_workers: int = field(default_factory=_max_workers_from_env)
+
+
+__all__ = ["DownloadOptions"]

--- a/program_youtube_downloader/constants.py
+++ b/program_youtube_downloader/constants.py
@@ -34,3 +34,11 @@ class MenuOption(Enum):
 
 # Base URL used to validate YouTube links throughout the project.
 BASE_YOUTUBE_URL = "https://www.youtube.com"
+
+__all__ = [
+    "TITLE_PROGRAM",
+    "TITLE_QUESTION_MENU_ACCUEIL",
+    "CHOICE_MENU_ACCUEIL",
+    "MenuOption",
+    "BASE_YOUTUBE_URL",
+]

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -374,3 +374,6 @@ class YoutubeDownloader:
         self._report_errors(futures)
         return None
 
+
+__all__ = ["YoutubeDownloader"]
+

--- a/program_youtube_downloader/exceptions.py
+++ b/program_youtube_downloader/exceptions.py
@@ -29,3 +29,15 @@ class DirectoryCreationError(PydlError):
 class InvalidURLError(PydlError):
     """Raised when a provided URL does not match expected YouTube patterns."""
 
+
+__all__ = [
+    "PydlError",
+    "DownloadError",
+    "ValidationError",
+    "PlaylistConnectionError",
+    "ChannelConnectionError",
+    "StreamAccessError",
+    "DirectoryCreationError",
+    "InvalidURLError",
+]
+

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -157,6 +157,20 @@ def main(
         raise SystemExit(f"Unknown command: {command}")
 
 
+__all__ = [
+    "setup_logging",
+    "parse_args",
+    "create_download_options",
+    "handle_quit_option",
+    "handle_video_option",
+    "handle_videos_option",
+    "handle_playlist_option",
+    "handle_channel_option",
+    "menu",
+    "main",
+]
+
+
 if __name__ == "__main__":  # pragma: no cover
     main()
 

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -110,3 +110,13 @@ class VerboseProgressHandler:
         downloaded = total - bytes_remaining
         percent = (downloaded / total) * 100
         print(f"{percent:.2f}%")
+
+
+__all__ = [
+    "ProgressHandler",
+    "on_download_progress",
+    "ProgressOptions",
+    "progress_bar",
+    "ProgressBarHandler",
+    "VerboseProgressHandler",
+]

--- a/program_youtube_downloader/types.py
+++ b/program_youtube_downloader/types.py
@@ -12,3 +12,6 @@ class YouTubeVideo(Protocol):
 
     def register_on_progress_callback(self, cb) -> None:  # pragma: no cover - typing stub
         ...
+
+
+__all__ = ["YouTubeVideo"]

--- a/program_youtube_downloader/validators.py
+++ b/program_youtube_downloader/validators.py
@@ -51,3 +51,6 @@ def validate_youtube_url(url: str) -> bool:
 
     return True
 
+
+__all__ = ["validate_youtube_url"]
+


### PR DESCRIPTION
## Summary
- declare __all__ lists across package modules
- reference `get_video_streams` instead of old name in docs
- update tests overview documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684747ce58088321a2dbf713e1baf400