### PR TITLE
Restore French messages

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,13 @@
+# Contribution guidelines
+
+Ce projet utilise le module `logging` de Python pour signaler l'état et les erreurs. Lors de l'ajout de nouveaux messages :
+
+- Écrire les messages de journal en **français**.
+- Utiliser des f-strings pour interpoler les variables.
+- Rester concis et éviter les préfixes tels que `[ERREUR]`.
+
+Example:
+
+```python
+logger.error(f"Echec du téléchargement : {exc}")
+```

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -46,7 +46,7 @@ def ask_numeric_value(min_value: int, max_value: int, max_attempts: int = 3) -> 
         try:
             v_int = int(v_str)
         except ValueError:
-            logger.warning("FAIL : Vous devez rentrer une valeur numérique.")
+            logger.warning("Entrée invalide : saisissez une valeur numérique.")
             logger.info("")
             attempts += 1
             if attempts >= max_attempts:
@@ -54,7 +54,7 @@ def ask_numeric_value(min_value: int, max_value: int, max_attempts: int = 3) -> 
             continue
         if not (min_value <= v_int <= max_value):
             logger.warning(
-                f"FAIL : Vous devez rentrer un nombre (entre {min_value} et {max_value} )."
+                f"Entrée invalide : saisissez un nombre entre {min_value} et {max_value}."
             )
             logger.info("")
             attempts += 1
@@ -123,13 +123,13 @@ def ask_save_file_path(max_attempts: int = 3) -> Path:
                     path.mkdir(parents=True, exist_ok=True)
                 except OSError:
                     logger.exception("Directory creation failed")
-                    logger.error("[ERREUR] : Impossible de créer le dossier")
+                    logger.error("Impossible de créer le dossier")
                     attempts += 1
                     if attempts >= max_attempts:
                         raise DirectoryCreationError("Création du dossier impossible")
                     continue
             else:
-                logger.error("[ERREUR] : Le dossier n'existe pas")
+                logger.error("Le dossier n'existe pas")
                 attempts += 1
                 if attempts >= max_attempts:
                     raise ValidationError("Dossier invalide")
@@ -167,8 +167,8 @@ def ask_youtube_url(max_attempts: int = 3) -> str:
             validate_youtube_url(url)
             return url
         except InvalidURLError:
-            logger.error("ERREUR : Vous devez renter une URL de vidéo youtube")
-            logger.error("le prefixe attendu est : https://www.youtube.com/")
+            logger.error("URL invalide : vous devez saisir le lien d'une vidéo YouTube")
+            logger.error("Préfixe attendu : https://www.youtube.com/")
             attempts += 1
             if attempts >= max_attempts:
                 raise ValidationError("URL invalide")
@@ -207,7 +207,9 @@ def ask_youtube_link_file(max_attempts: int = 3) -> list[str]:
                 total_links = len(lines)
 
                 if not total_links:
-                    logger.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
+                    logger.error(
+                        "Vous devez fournir un fichier contenant au moins une URL de vidéo YouTube"
+                    )
                     attempts += 1
                     if attempts >= max_attempts:
                         raise ValidationError("Aucune URL valide")
@@ -220,23 +222,23 @@ def ask_youtube_link_file(max_attempts: int = 3) -> list[str]:
                         validate_youtube_url(video_url)
                         valid_urls.append(video_url)
                     except InvalidURLError:
-                        logger.error("[ERREUR] : ")
-                        logger.error("le prefixe attendu est : https://www.youtube.com/")
                         logger.error(
-                            f"  le lien sur la ligne n° {line_counter} ne sera pas télécharger"
+                            f"URL invalide à la ligne {line_counter} ; le préfixe attendu est : https://www.youtube.com/"
                         )
                         logger.error("")
                         error_count += 1
 
                 if error_count == total_links:
-                    logger.error("[ERREUR] : Vous devez fournir un fichier avec au minimum une URL de vidéo youtube")
+                    logger.error(
+                        "Vous devez fournir un fichier contenant au moins une URL de vidéo YouTube"
+                    )
                     attempts += 1
                     if attempts >= max_attempts:
                         raise ValidationError("Aucune URL valide")
                     continue
         except OSError:
-            logger.exception("[ERREUR] : Le fichier n'est pas accessible")
-            logger.error("[ERREUR] : Le fichier n'est pas accessible")
+            logger.exception("Le fichier n'est pas accessible")
+            logger.error("Le fichier n'est pas accessible")
             attempts += 1
             if attempts >= max_attempts:
                 raise ValidationError("Fichier inaccessible")

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -57,15 +57,15 @@ class YoutubeDownloader:
                 yt.register_on_progress_callback(progress_handler.on_progress)
             return yt
         except KeyError as e:
-            logger.error("[ERREUR] : Problème de clé dans les données : %s", e)
+            logger.error(f"Problème de clé dans les données : {e}")
             return None
         except PytubeError as e:
             logger.exception("Error while connecting to video")
-            logger.error("[ERREUR] : Connexion à la vidéo impossible : %s", e)
+            logger.error(f"Connexion à la vidéo impossible : {e}")
             return None
         except Exception as e:  # pragma: no cover - defensive
             logger.exception("Unexpected error while connecting to video")
-            logger.error("[ERREUR] : Connexion à la vidéo impossible : %s", e)
+            logger.error(f"Connexion à la vidéo impossible : {e}")
             return None
 
     def _select_stream(
@@ -95,7 +95,7 @@ class YoutubeDownloader:
         current_file = save_path / stream.default_filename  # type: ignore
         if current_file.exists():
             logger.warning(
-                "[WARNING] un fichier MP4 portant le même nom, déjà existant!"
+                "Un fichier MP4 portant le même nom existe déjà"
             )
 
         out_file = None
@@ -107,7 +107,7 @@ class YoutubeDownloader:
             except (HTTPError, OSError, PytubeError) as e:  # pragma: no cover - network/io issues
                 logger.exception("Download failed")
                 logger.info("")
-                logger.error("[ERREUR] : le téléchargement a échoué : %s", e)
+                logger.error(f"Le téléchargement a échoué : {e}")
                 logger.info("")
                 if attempt == 2:
                     raise DownloadError(
@@ -116,7 +116,7 @@ class YoutubeDownloader:
             except Exception as e:  # pragma: no cover - defensive
                 logger.exception("Unexpected error during download")
                 logger.info("")
-                logger.error("[ERREUR] : le téléchargement a échoué : %s", e)
+                logger.error(f"Le téléchargement a échoué : {e}")
                 logger.info("")
                 if attempt == 2:
                     raise DownloadError(
@@ -147,23 +147,17 @@ class YoutubeDownloader:
             return streams
         except HTTPError as e:
             logger.error(
-                "[ERREUR] : Impossible d'accéder aux flux pour la vidéo. Code HTTP : %s, Message : %s",
-                e.code,
-                e.reason,
+                f"Impossible d'accéder aux flux pour la vidéo. HTTP {e.code} : {e.reason}"
             )
             raise StreamAccessError(f"HTTP {e.code}: {e.reason}") from e
         except PytubeError as e:
             logger.exception("Error while retrieving streams")
-            logger.error(
-                "[ERREUR] : Une erreur est survenue lors de la récupération des flux : %s",
-                e,
-            )
+            logger.error(f"Une erreur est survenue lors de la récupération des flux : {e}")
             raise StreamAccessError(str(e)) from e
         except Exception as e:  # pragma: no cover - defensive
             logger.exception("Unexpected error while retrieving streams")
             logger.error(
-                "[ERREUR] : Une erreur inattendue s'est produite lors de la récupération des flux : %s",
-                e,
+                f"Une erreur inattendue s'est produite lors de la récupération des flux : {e}"
             )
             raise StreamAccessError(str(e)) from e
 
@@ -192,7 +186,7 @@ class YoutubeDownloader:
                 file_path.unlink()
         except OSError:
             logger.exception("Error during MP4 to MP3 conversion")
-            logger.warning("[WARNING] un fichier MP3 portant le même nom, déjà existant!")
+            logger.warning("Un fichier MP3 portant le même nom existe déjà")
             if file_path.exists():
                 file_path.unlink()
             logger.info("")
@@ -213,16 +207,13 @@ class YoutubeDownloader:
             streams = self.get_video_streams(download_sound_only, youtube_video)
         except StreamAccessError as e:
             logger.error(
-                "[ERREUR] : Les flux pour la vidéo (%s) n'ont pas pu être récupérés. %s",
-                video_url,
-                e,
+                f"Les flux pour la vidéo {video_url} n'ont pas pu être récupérés : {e}"
             )
             return None
 
         if not streams:
             logger.error(
-                "[ERREUR] : Aucun flux disponible pour la vidéo (%s).",
-                video_url,
+                f"Aucun flux disponible pour la vidéo {video_url}."
             )
             return None
 
@@ -230,16 +221,13 @@ class YoutubeDownloader:
             video_title = youtube_video.title
         except KeyError as e:
             logger.error(
-                "[ERREUR] : Impossible d'accéder au titre de la vidéo %s. Détail : %s",
-                video_url,
-                e,
+                f"Impossible d'accéder au titre de la vidéo {video_url}. Détail : {e}"
             )
             return None
         except PytubeError as e:
             logger.exception("Error while accessing video title")
             logger.error(
-                "[ERREUR] : Une erreur est survenue lors de l'accès au titre : %s",
-                e,
+                f"Une erreur est survenue lors de l'accès au titre : {e}"
             )
             return None
         except Exception:  # pragma: no cover - defensive
@@ -286,8 +274,7 @@ class YoutubeDownloader:
             cli_utils.print_end_download_message()
         else:
             logger.error(
-                "[ERREUR] : Les téléchargements suivants ont échoué : %s",
-                ", ".join(errors),
+                f"Les téléchargements suivants ont échoué : {', '.join(errors)}"
             )
         cli_utils.pause_return_to_menu()
 
@@ -320,7 +307,7 @@ class YoutubeDownloader:
 
         url_list = list(youtube_video_urls)
         if not url_list:
-            logger.error("[ERREUR] : il y a aucune vidéo à télécharger")
+            logger.error("Il n'y a aucune vidéo à télécharger")
             return None
 
         if options.max_workers < 1:
@@ -349,18 +336,17 @@ class YoutubeDownloader:
                     logger.info("")
                     logger.info("")
                     cli_utils.print_separator()
-                    logger.info("*             Stream vidéo selectionnée:         *")
+                    logger.info("*             Stream vidéo sélectionné :          *")
                     cli_utils.print_separator()
                     logger.info(
-                        "Number of link url video youtube in file: %s",
-                        len(url_list),
+                        f"Nombre de liens vidéo YouTube dans le fichier : {len(url_list)}"
                     )
                     logger.info("")
 
                 itag = streams[choice_user - 1].itag  # type: ignore
                 stream = youtube_video.streams.get_by_itag(itag)
 
-                logger.info("Titre: %s", video_title[0:53])
+                logger.info(f"Titre : {video_title[0:53]}")
 
                 self._submit_download(
                     executor,

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -93,7 +93,7 @@ class ProgressBarHandler:
         """Compute percentage and forward it to :func:`progress_bar`."""
         total_bytes_download = getattr(stream, "filesize", None)
         if not total_bytes_download:
-            logger.warning("Missing total filesize. Assuming complete")
+            logger.warning("Taille totale manquante, téléchargement supposé terminé")
             progress = 100.0
         else:
             bytes_downloaded = total_bytes_download - bytes_remaining

--- a/program_youtube_downloader/utils.py
+++ b/program_youtube_downloader/utils.py
@@ -20,7 +20,7 @@ def clear_screen() -> None:
         else:
             subprocess.run(["cmd", "/c", "cls"], check=True)
     except subprocess.CalledProcessError as exc:  # pragma: no cover - failure path
-        logger.warning("Failed to clear screen: %s", exc)
+        logger.warning(f"Échec de l'effacement de l'écran : {exc}")
         return
 
 


### PR DESCRIPTION
## Summary
- revert log strings to French following feedback
- keep f-strings and remove tags
- adjust contribution guideline and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68474b9db2948321b5ddb99b4c4f5afd