### PR TITLE
Refactor progress callbacks with ProgressEvent

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -31,6 +31,7 @@ Fonctions d'interaction utilisateur :
 
 ## `progress.py`
 - `on_download_progress(stream, chunk, remaining)` : gestionnaire simple de progression.
+- `ProgressEvent` : informations structurées sur l'avancement d'un téléchargement.
 - `ProgressOptions` : configuration de l'affichage de la barre.
 - `progress_bar(progress, options=None)` : affiche une barre de progression dans le terminal.
 - `ProgressBarHandler` : implémente `on_progress` pour `pytubefix`.

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -12,6 +12,7 @@ from program_youtube_downloader import cli_utils, utils
 from program_youtube_downloader.downloader import YoutubeDownloader
 from program_youtube_downloader.exceptions import DownloadError, StreamAccessError
 from program_youtube_downloader.config import DownloadOptions
+from program_youtube_downloader import progress
 from program_youtube_downloader.progress import (
     progress_bar,
     ProgressBarHandler,
@@ -123,7 +124,8 @@ def test_progressbarhandler_on_progress(capsys):
     """The default handler should print the current percentage."""
     handler = ProgressBarHandler()
     stream = DummyStream()
-    handler.on_progress(stream, b"", bytes_remaining=500)
+    event = progress.create_progress_event(stream, 500)
+    handler.on_progress(event)
     out = capsys.readouterr().out
     assert "50.00%" in out
 
@@ -140,7 +142,8 @@ def test_progressbarhandler_no_total(caplog, capsys, size):
     handler = ProgressBarHandler()
     stream = Stream(size)
     with caplog.at_level(logging.WARNING):
-        handler.on_progress(stream, b"", bytes_remaining=50)
+        event = progress.create_progress_event(stream, 50)
+        handler.on_progress(event)
     out = capsys.readouterr().out
     assert "100.00%" in out
     assert "filesize" in caplog.text.lower()
@@ -150,7 +153,8 @@ def test_verboseprogresshandler_on_progress(capsys):
     """Verbose handler should print only the percentage."""
     handler = VerboseProgressHandler()
     stream = DummyStream()
-    handler.on_progress(stream, b"", bytes_remaining=750)
+    event = progress.create_progress_event(stream, 750)
+    handler.on_progress(event)
     out = capsys.readouterr().out.strip()
     assert out.endswith("25.00%")
 

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -35,8 +35,8 @@ def test_progress_bar_complete(capsys):
 def test_on_download_progress_wrapper(monkeypatch):
     called = {}
 
-    def fake(self, stream, chunk, remaining):
-        called["ok"] = True
+    def fake(self, event):
+        called["ok"] = isinstance(event, progress.ProgressEvent)
 
     monkeypatch.setattr(progress.ProgressBarHandler, "on_progress", fake)
     progress.on_download_progress(None, None, 0)


### PR DESCRIPTION
## Summary
- add `ProgressEvent` dataclass and helper to build it
- update progress handlers to use `ProgressEvent`
- wrap pytube callbacks to build events
- adjust tests for new progress event structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68474e2c7cbc83219a3f356606e854ab