### PR TITLE
Update docs for log level and progress options

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,10 +68,12 @@ yd.conversion_mp4_in_mp3("video.mp4")
 **Points d'entrée** :
 - `on_download_progress()` dans [program_youtube_downloader/progress.py](program_youtube_downloader/progress.py).
 - `progress_bar()` dans [program_youtube_downloader/progress.py](program_youtube_downloader/progress.py).
+- Dataclass `ProgressOptions` pour personnaliser l'affichage.
+- Classes `ProgressBarHandler` et `VerboseProgressHandler` implémentant `ProgressHandler`.
 
 **Entrées** : rappels de flux provenant de `pytubefix`, pourcentages d'avancement.
 
-**Sorties** : barre de progression textuelle dans la console.
+**Sorties** : barre de progression textuelle dans la console ou simple pourcentage.
 
 Utilisation :
 ```python
@@ -121,10 +123,10 @@ value = ask_numeric_value(1, 3)
 
 | Agent | Fichier(s) | Fonctions principales |
 |-------|------------|----------------------|
-| Agent CLI | `program_youtube_downloader/main.py`, `program_youtube_downloader/cli.py` | `main()`, classe `CLI` |
+| Agent CLI | `program_youtube_downloader/main.py`, `program_youtube_downloader/cli.py` | `setup_logging`, `parse_args`, `main()`, classe `CLI` |
 | Agent de téléchargement | `downloader.py` | `download_multiple_videos` |
 | Agent de conversion | `downloader.py` | `conversion_mp4_in_mp3` |
-| Agent de progression | `program_youtube_downloader/progress.py` | `on_download_progress`, `progress_bar` |
+| Agent de progression | `program_youtube_downloader/progress.py` | `on_download_progress`, `progress_bar`, `ProgressOptions`, `ProgressBarHandler`, `VerboseProgressHandler` |
 | Agent de validation | `program_youtube_downloader/cli_utils.py` | `ask_numeric_value`, `ask_youtube_url`, `ask_youtube_link_file` |
 | Agent des constantes | `program_youtube_downloader/constants.py` | libellés du menu, `BASE_YOUTUBE_URL` |
 | Agent de configuration | `program_youtube_downloader/config.py` | dataclass `DownloadOptions` |

--- a/README.md
+++ b/README.md
@@ -145,6 +145,16 @@ handler = VerboseProgressHandler()
 yd = YoutubeDownloader(progress_handler=handler)
 ```
 
+Vous pouvez également personnaliser l'apparence de la barre de
+progression grâce à la dataclass `ProgressOptions` :
+
+```python
+from program_youtube_downloader.progress import ProgressBarHandler, ProgressOptions
+
+options = ProgressOptions(size=50, prefix_end="Fini !")
+yd = YoutubeDownloader(progress_handler=ProgressBarHandler(options))
+```
+
 Pour une description détaillée des agents internes et de leurs responsabilités,
 consultez [AGENTS.md](AGENTS.md) à la racine du dépôt.
 

--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -3,7 +3,8 @@
 Cette section décrit brièvement les fonctions et classes disponibles dans le package `program_youtube_downloader`.
 
 ## `program_youtube_downloader/main.py`
-- **`parse_args(argv=None)`** : analyse les arguments de la ligne de commande et retourne un objet `argparse.Namespace`.
+- **`setup_logging(level)`** : configure le module `logging` pour l'application.
+- **`parse_args(argv=None)`** : analyse les arguments de la ligne de commande et lit la variable d'environnement `PYDL_LOG_LEVEL` pour le niveau par défaut.
 - **`menu()`** : lance le menu interactif (non couvert par les tests).
 - **`main(argv=None)`** : point d'entrée principal qui redirige vers les sous-commandes ou le menu.
 - **`create_download_options(audio_only, output_dir=None)`** : construit un objet `DownloadOptions` prêt à l'emploi.
@@ -31,13 +32,13 @@ Fonctions d'interaction utilisateur :
 
 ## `progress.py`
 - `on_download_progress(stream, chunk, remaining)` : gestionnaire simple de progression.
-- `ProgressOptions` : configuration de l'affichage de la barre.
+- `ProgressOptions` : dataclass de configuration de la barre.
 - `progress_bar(progress, options=None)` : affiche une barre de progression dans le terminal.
 - `ProgressBarHandler` : implémente `on_progress` pour `pytubefix`.
 - `VerboseProgressHandler` : affiche uniquement le pourcentage sans barre.
 
 ## `config.py`
-- `DownloadOptions` : dataclass regroupant les options de téléchargement (dossier, audio seul, callback de choix, gestionnaire de progression, nombre de threads).
+- `DownloadOptions` : dataclass regroupant les options de téléchargement (dossier, audio seul, callback de choix, gestionnaire de progression, nombre de threads). Le champ `max_workers` est initialisé depuis la variable d'environnement `PYDL_MAX_WORKERS` si elle est définie.
 
 ## `youtube_downloader.py`
 Utilitaires généraux :

--- a/docs/releases/changelog.md
+++ b/docs/releases/changelog.md
@@ -5,7 +5,8 @@ Toutes les modifications notables sont listées par version.
 Le format est inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0/).
 
 ## [Unreleased]
-- Documentez ici les changements prévus pour la prochaine version.
+- Ajout de la variable d'environnement `PYDL_LOG_LEVEL` pour contrôler la verbosité des logs.
+- Nouvelle dataclass `ProgressOptions` et gestionnaires `ProgressBarHandler`/`VerboseProgressHandler` pour suivre l'avancement des téléchargements.
 
 ## [0.1.0] - 2025-06-06
 ### Added

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -143,7 +143,8 @@ def test_progressbarhandler_no_total(caplog, capsys, size):
         handler.on_progress(stream, b"", bytes_remaining=50)
     out = capsys.readouterr().out
     assert "100.00%" in out
-    assert "filesize" in caplog.text.lower()
+    text = caplog.text.lower()
+    assert "filesize" in text or "taille totale" in text
 
 
 def test_verboseprogresshandler_on_progress(capsys):
@@ -195,7 +196,8 @@ def test_clear_screen_error(monkeypatch, caplog):
     monkeypatch.setattr(utils.subprocess, "run", fail_run)
     with caplog.at_level(logging.WARNING):
         utils.clear_screen()
-    assert "Failed to clear screen" in caplog.text
+    text = caplog.text
+    assert "Failed to clear screen" in text or "Échec de l'effacement" in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- document PYDL_LOG_LEVEL default in API reference
- document ProgressOptions and progress handlers in API reference and README
- update agents overview with new helper methods
- note changes in changelog
- adjust tests for localized log messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684752112efc8321a5b8a18567ae35c8