### PR TITLE
Deprecate legacy_utils module

### DIFF
--- a/program_youtube_downloader/__init__.py
+++ b/program_youtube_downloader/__init__.py
@@ -1,7 +1,7 @@
 """Public exports for program_youtube_downloader."""
 from .exceptions import PydlError, DownloadError, ValidationError
-# re-export legacy utilities
-from .legacy_utils import clear_screen, program_break_time
+# re-export utilities
+from .utils import clear_screen, program_break_time
 
 __all__ = [
     "PydlError",

--- a/program_youtube_downloader/legacy_utils.py
+++ b/program_youtube_downloader/legacy_utils.py
@@ -1,4 +1,8 @@
-"""Backward compatibility utilities (deprecated)."""
+"""Deprecated helper wrapper to preserve old imports.
+
+Import :func:`clear_screen` and :func:`program_break_time` from
+``program_youtube_downloader.utils`` instead.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- update __init__ to re-export helpers from utils
- mark legacy_utils as deprecated

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480262537c8321994b0ff8476afcdc