### PR TITLE
Add missing docstrings

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -15,6 +15,9 @@ Cette section décrit brièvement les fonctions et classes disponibles dans le p
   - `conversion_mp4_in_mp3(path)` : convertit un fichier MP4 en MP3 et supprime l'original.
   - `download_multiple_videos(urls, options)` : télécharge une liste d'URL ou de ressources YouTube.
 
+## `cli.py`
+- `CLI` : interface interactive basée sur `YoutubeDownloader`.
+
 ## `cli_utils.py`
 Fonctions d'interaction utilisateur :
 - `print_separator()` : affiche un séparateur visuel.
@@ -40,6 +43,7 @@ Fonctions d'interaction utilisateur :
 
 ## `config.py`
 - `DownloadOptions` : dataclass regroupant les options de téléchargement (dossier, audio seul, callback de choix, gestionnaire de progression, nombre de threads). Le champ `max_workers` est initialisé depuis la variable d'environnement `PYDL_MAX_WORKERS` si elle est définie.
+- `_max_workers_from_env()` : récupère `PYDL_MAX_WORKERS` et retourne `1` en cas de valeur invalide.
 
 ## `legacy_utils.py`
 Utilitaires généraux :

--- a/program_youtube_downloader/cli.py
+++ b/program_youtube_downloader/cli.py
@@ -21,6 +21,12 @@ class CLI:
     """Interactive command line interface for the application."""
 
     def __init__(self, downloader: YoutubeDownloader | None = None) -> None:
+        """Create the CLI wrapper around ``YoutubeDownloader``.
+
+        Args:
+            downloader: Optional custom downloader instance. When ``None`` a
+                new :class:`YoutubeDownloader` is created.
+        """
         self.downloader = downloader or YoutubeDownloader()
 
     # ------------------------------------------------------------------

--- a/program_youtube_downloader/config.py
+++ b/program_youtube_downloader/config.py
@@ -7,6 +7,7 @@ from .progress import ProgressHandler
 
 
 def _max_workers_from_env() -> int:
+    """Return ``PYDL_MAX_WORKERS`` as an integer or fallback to ``1``."""
     value = os.getenv("PYDL_MAX_WORKERS")
     if value is None:
         return 1

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -59,6 +59,7 @@ class YoutubeDownloader:
             yt = self.youtube_cls(url)
             if progress_handler:
                 def _wrapper(stream, chunk, bytes_remaining):
+                    """Translate pytube progress callback to :class:`ProgressEvent`."""
                     event = create_progress_event(stream, bytes_remaining)
                     progress_handler.on_progress(event)
 

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -109,6 +109,7 @@ class ProgressBarHandler:
     """Default progress handler displaying a textual bar."""
 
     def __init__(self, options: ProgressOptions | None = None) -> None:
+        """Instantiate the handler with optional display options."""
         self.options = options
 
 

--- a/program_youtube_downloader/types.py
+++ b/program_youtube_downloader/types.py
@@ -8,9 +8,13 @@ class YouTubeVideo(Protocol):
 
     @property
     def title(self) -> str:  # pragma: no cover - typing stub
+        """Return the video title."""
+
         ...
 
     def register_on_progress_callback(self, cb) -> None:  # pragma: no cover - typing stub
+        """Register a callback invoked during downloads."""
+
         ...
 
 


### PR DESCRIPTION
## Summary
- audit modules for missing docstrings
- add docstrings in CLI, progress bar handler, config helpers and typing stubs
- document CLI and helper in API reference

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848032d2ef08321bce39fdfab00d53c