### PR TITLE
Add stricter YouTube ID validation

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -31,7 +31,8 @@ Fonctions d'interaction utilisateur :
 - `pause_return_to_menu()` : attend une touche avant de revenir au menu.
 
 ## `validators.py`
-- `validate_youtube_url(url)` : vérifie qu'une URL appartient bien à YouTube.
+- `validate_youtube_url(url)` : vérifie qu'une URL appartient bien à YouTube et
+  que l'identifiant vidéo extrait contient exactement 11 caractères valides.
 
 ## `progress.py`
 - `on_download_progress(stream, chunk, remaining)` : gestionnaire simple de progression.

--- a/program_youtube_downloader/validators.py
+++ b/program_youtube_downloader/validators.py
@@ -1,6 +1,7 @@
 """Input validation helpers."""
 
 from urllib.parse import urlparse, parse_qs
+import re
 
 from .exceptions import InvalidURLError
 
@@ -47,6 +48,9 @@ def validate_youtube_url(url: str) -> bool:
             video_id = path.split("/", 1)[0]
 
     if not video_id:
+        raise InvalidURLError("URL invalide")
+
+    if not re.fullmatch(r"[A-Za-z0-9_-]{11}", video_id):
         raise InvalidURLError("URL invalide")
 
     return True

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -7,6 +7,8 @@ from program_youtube_downloader.exceptions import (
     DirectoryCreationError,
 )
 
+VALID_ID = "dQw4w9WgXcQ"
+
 
 def test_ask_numeric_value_retries(monkeypatch):
     inputs = iter(["foo", "5", "2"])
@@ -18,31 +20,31 @@ def test_ask_numeric_value_retries(monkeypatch):
 def test_ask_youtube_url_normalizes_channel(monkeypatch):
     inputs = iter([
         "https://www.youtube.com/@MyChannel",
-        "https://www.youtube.com/watch?v=good",
+        f"https://www.youtube.com/watch?v={VALID_ID}",
     ])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
     url = cli_utils.ask_youtube_url()
-    assert url == "https://www.youtube.com/watch?v=good"
+    assert url == f"https://www.youtube.com/watch?v={VALID_ID}"
 
 
 def test_ask_youtube_url_invalid_prefix(monkeypatch):
     inputs = iter([
         "http://example.com/video",
-        "https://www.youtube.com/watch?v=ok",
+        f"https://www.youtube.com/watch?v={VALID_ID}",
     ])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
     url = cli_utils.ask_youtube_url()
-    assert url == "https://www.youtube.com/watch?v=ok"
+    assert url == f"https://www.youtube.com/watch?v={VALID_ID}"
 
 
 def test_ask_youtube_url_invalid_then_valid(monkeypatch):
     inputs = iter([
         "invalid",
-        "https://www.youtube.com/watch?v=good",
+        f"https://www.youtube.com/watch?v={VALID_ID}",
     ])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
     url = cli_utils.ask_youtube_url()
-    assert url == "https://www.youtube.com/watch?v=good"
+    assert url == f"https://www.youtube.com/watch?v={VALID_ID}"
 
 
 def test_ask_save_file_path_existing(tmp_path, monkeypatch):
@@ -104,14 +106,14 @@ def test_ask_save_file_path_dircreation_error(monkeypatch, tmp_path):
 def test_ask_youtube_link_file(monkeypatch, tmp_path):
     links_file = tmp_path / "links.txt"
     links_file.write_text(
-        "https://www.youtube.com/watch?v=ok\ninvalid\nhttps://youtu.be/abc\n"
+        f"https://www.youtube.com/watch?v={VALID_ID}\ninvalid\nhttps://youtu.be/{VALID_ID}\n"
     )
     inputs = iter([str(links_file)])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
     links = cli_utils.ask_youtube_link_file()
     assert links == [
-        "https://www.youtube.com/watch?v=ok",
-        "https://youtu.be/abc",
+        f"https://www.youtube.com/watch?v={VALID_ID}",
+        f"https://youtu.be/{VALID_ID}",
     ]
 
 

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -94,11 +94,11 @@ def test_ask_youtube_link_file_all_invalid(monkeypatch, tmp_path):
     bad = tmp_path / "bad.txt"
     bad.write_text("not_a_url\n")
     good = tmp_path / "good.txt"
-    good.write_text("https://youtu.be/ok\n")
+    good.write_text("https://youtu.be/dQw4w9WgXcQ\n")
     inputs = iter([str(bad), str(good)])
     monkeypatch.setattr(builtins, "input", lambda *a, **k: next(inputs))
     links = cli_utils.ask_youtube_link_file()
-    assert links == ["https://youtu.be/ok"]
+    assert links == ["https://youtu.be/dQw4w9WgXcQ"]
 
 
 def test_ask_youtube_link_file_oserror(monkeypatch, tmp_path):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -4,14 +4,26 @@ from program_youtube_downloader.validators import validate_youtube_url
 from program_youtube_downloader.exceptions import InvalidURLError
 
 
+VALID_ID = "dQw4w9WgXcQ"
+
+
 def test_validate_youtube_url_valid() -> None:
-    assert validate_youtube_url("https://www.youtube.com/watch?v=ok") is True
-    assert validate_youtube_url("https://youtube.com/watch?v=ok") is True
-    assert validate_youtube_url("https://youtu.be/abc") is True
-    assert validate_youtube_url("https://www.youtube.com/watch?v=ok&list=123") is True
-    assert validate_youtube_url("https://youtu.be/abc?list=xyz") is True
-    assert validate_youtube_url("https://YouTube.com/watch?v=ok&t=5") is True
-    assert validate_youtube_url("https://youtu.be/abc/") is True
+    assert (
+        validate_youtube_url(f"https://www.youtube.com/watch?v={VALID_ID}") is True
+    )
+    assert validate_youtube_url(f"https://youtube.com/watch?v={VALID_ID}") is True
+    assert validate_youtube_url(f"https://youtu.be/{VALID_ID}") is True
+    assert (
+        validate_youtube_url(
+            f"https://www.youtube.com/watch?v={VALID_ID}&list=123"
+        )
+        is True
+    )
+    assert validate_youtube_url(f"https://youtu.be/{VALID_ID}?list=xyz") is True
+    assert (
+        validate_youtube_url(f"https://YouTube.com/watch?v={VALID_ID}&t=5") is True
+    )
+    assert validate_youtube_url(f"https://youtu.be/{VALID_ID}/") is True
 
 
 def test_validate_youtube_url_invalid() -> None:
@@ -35,6 +47,23 @@ def test_validate_youtube_url_invalid() -> None:
 
 def test_validate_youtube_url_rejects_extra_chars() -> None:
     with pytest.raises(InvalidURLError):
-        validate_youtube_url("https://www.youtube.com/watch?v=ok extra")
+        validate_youtube_url(
+            f"https://www.youtube.com/watch?v={VALID_ID} extra"
+        )
     with pytest.raises(InvalidURLError):
-        validate_youtube_url("https://youtu.be/abc extra")
+        validate_youtube_url(f"https://youtu.be/{VALID_ID} extra")
+
+
+def test_validate_youtube_url_bad_length() -> None:
+    with pytest.raises(InvalidURLError):
+        validate_youtube_url("https://www.youtube.com/watch?v=shortid")
+    with pytest.raises(InvalidURLError):
+        validate_youtube_url("https://youtu.be/too_long_id12")
+
+
+def test_validate_youtube_url_bad_chars() -> None:
+    bad = "dQw4w9WgXcQ!"
+    with pytest.raises(InvalidURLError):
+        validate_youtube_url(f"https://www.youtube.com/watch?v={bad}")
+    with pytest.raises(InvalidURLError):
+        validate_youtube_url(f"https://youtu.be/{bad}")


### PR DESCRIPTION
## Summary
- validate_youtube_url now checks for 11-character IDs
- add tests for video ID length and characters
- update existing tests with valid IDs
- document stricter validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848059204908321aaea5460e1c86e11