### PR TITLE
Truncate URLs in logs

### DIFF
--- a/docs/releases/changelog.md
+++ b/docs/releases/changelog.md
@@ -8,6 +8,8 @@ Le format est inspiré de [Keep a Changelog](https://keepachangelog.com/fr/1.1.0
 - Ajout de la variable d'environnement `PYDL_LOG_LEVEL` pour contrôler la verbosité des logs.
 - Nouvelle dataclass `ProgressOptions` et gestionnaires `ProgressBarHandler`/`VerboseProgressHandler` pour suivre l'avancement des téléchargements.
 - Renommage de `youtube_downloader.py` en `legacy_utils.py`.
+- Les URL des vidéos sont tronquées dans les messages de log pour éviter d'afficher
+  l'adresse complète.
 
 ## [0.1.0] - 2025-06-06
 ### Added

--- a/program_youtube_downloader/__init__.py
+++ b/program_youtube_downloader/__init__.py
@@ -1,7 +1,7 @@
 """Public exports for program_youtube_downloader."""
 from .exceptions import PydlError, DownloadError, ValidationError
 # re-export utilities
-from .utils import clear_screen, program_break_time
+from .utils import clear_screen, program_break_time, shorten_url
 
 __all__ = [
     "PydlError",
@@ -9,4 +9,5 @@ __all__ = [
     "ValidationError",
     "clear_screen",
     "program_break_time",
+    "shorten_url",
 ]

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -15,6 +15,7 @@ from .progress import (
     ProgressBarHandler,
     create_progress_event,
 )
+from .utils import shorten_url
 
 logger = logging.getLogger(__name__)
 
@@ -227,13 +228,16 @@ class YoutubeDownloader:
             streams = self.get_video_streams(download_sound_only, youtube_video)
         except StreamAccessError as e:
             logger.error(
-                f"Les flux pour la vidéo {video_url} n'ont pas pu être récupérés : {e}"
+                "Les flux pour la vidéo %s n'ont pas pu être récupérés : %s",
+                shorten_url(video_url),
+                e,
             )
             return None
 
         if not streams:
             logger.error(
-                f"Aucun flux disponible pour la vidéo {video_url}."
+                "Aucun flux disponible pour la vidéo %s.",
+                shorten_url(video_url),
             )
             return None
 
@@ -241,7 +245,9 @@ class YoutubeDownloader:
             video_title = youtube_video.title
         except KeyError as e:
             logger.error(
-                f"Impossible d'accéder au titre de la vidéo {video_url}. Détail : {e}"
+                "Impossible d'accéder au titre de la vidéo %s. Détail : %s",
+                shorten_url(video_url),
+                e,
             )
             return None
         except PytubeError as e:
@@ -297,8 +303,10 @@ class YoutubeDownloader:
         if not errors:
             cli_utils.print_end_download_message()
         else:
+            failed = ", ".join(shorten_url(u) for u in errors)
             logger.error(
-                f"Les téléchargements suivants ont échoué : {', '.join(errors)}"
+                "Les téléchargements suivants ont échoué : %s",
+                failed,
             )
         cli_utils.pause_return_to_menu()
 

--- a/program_youtube_downloader/utils.py
+++ b/program_youtube_downloader/utils.py
@@ -6,8 +6,9 @@ import os
 import subprocess
 import time
 import logging
+from urllib.parse import urlparse, parse_qs
 
-__all__ = ["clear_screen", "program_break_time"]
+__all__ = ["clear_screen", "program_break_time", "shorten_url"]
 
 logger = logging.getLogger(__name__)
 
@@ -41,3 +42,19 @@ def program_break_time(memorization_time: int, message: str) -> None:
         time.sleep(1)
         print(f"{remaining_seconds} ", end="", flush=True)
         remaining_seconds -= 1
+
+
+def shorten_url(url: str) -> str:
+    """Return video ID from ``url`` for safer logging."""
+    try:
+        parsed = urlparse(url.strip())
+        host = parsed.netloc.lower()
+        if host in {"youtu.be", "www.youtu.be"}:
+            vid = parsed.path.strip("/").split("/", 1)[0]
+        else:
+            vid = parse_qs(parsed.query).get("v", [""])[0]
+        if vid:
+            return vid
+    except Exception:  # pragma: no cover - defensive
+        logger.debug("Failed to shorten url", exc_info=True)
+    return "<url>"

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -316,5 +316,5 @@ def test_download_multiple_videos_download_error(monkeypatch, tmp_path, caplog):
     options = DownloadOptions(save_path=tmp_path)
     with caplog.at_level(logging.ERROR):
         yd.download_multiple_videos(["https://youtu.be/fail"], options)
-    assert "https://youtu.be/fail" in caplog.text
+    assert "fail" in caplog.text
     assert not any(tmp_path.iterdir())

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -162,7 +162,7 @@ def test_report_errors(monkeypatch, caplog) -> None:
     with caplog.at_level(logging.ERROR):
         yd._report_errors(futures)
 
-    assert "https://youtu.be/b" in caplog.text
+    assert "b" in caplog.text
     assert "end" not in called
     assert "pause" in called
 
@@ -329,7 +329,7 @@ def test_download_multiple_videos_download_error(monkeypatch, tmp_path: Path, ca
     options = DownloadOptions(save_path=tmp_path)
     with caplog.at_level(logging.ERROR):
         yd.download_multiple_videos(["https://youtu.be/fail"], options)
-    assert "https://youtu.be/fail" in caplog.text
+    assert "fail" in caplog.text
     assert not any(tmp_path.iterdir())
 
 

--- a/tests/test_parallel_downloads.py
+++ b/tests/test_parallel_downloads.py
@@ -77,7 +77,7 @@ def test_parallel_error_collection(monkeypatch, tmp_path: Path, caplog):
     urls = ["https://youtu.be/a", "https://youtu.be/b"]
     with caplog.at_level(logging.ERROR):
         yd.download_multiple_videos(urls, options)
-    assert "https://youtu.be/b" in caplog.text
+    assert "b" in caplog.text
     assert (tmp_path / "a.mp4").exists()
     assert not (tmp_path / "b.mp4").exists()
 


### PR DESCRIPTION
## Summary
- log shortened video URLs using `utils.shorten_url`
- export the helper in `__init__`
- adjust tests for updated logging
- document security improvement in the changelog

## Testing
- `flake8` *(fails: E501, E303, etc.)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684807fbe03c832197f3949e36fce987