### PR TITLE
Allow CLI customization in main

### DIFF
--- a/docs/reference/api-reference.md
+++ b/docs/reference/api-reference.md
@@ -6,7 +6,9 @@ Cette section décrit brièvement les fonctions et classes disponibles dans le p
 - **`setup_logging(level)`** : configure le module `logging` pour l'application.
 - **`parse_args(argv=None)`** : analyse les arguments de la ligne de commande et lit la variable d'environnement `PYDL_LOG_LEVEL` pour le niveau par défaut.
 - **`menu()`** : lance le menu interactif (non couvert par les tests).
-- **`main(argv=None)`** : point d'entrée principal qui redirige vers les sous-commandes ou le menu.
+ - **`main(argv=None, downloader=None, cli_cls=CLI)`** : point d'entrée principal
+   qui redirige vers les sous-commandes ou le menu. Le paramètre `cli_cls`
+   permet d'utiliser une sous-classe personnalisée de `CLI`.
 - **`create_download_options(audio_only, output_dir=None)`** : construit un objet `DownloadOptions` prêt à l'emploi.
 
 ## `downloader.py`

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -30,6 +30,10 @@ Le cœur de l’application se trouve dans le package `program_youtube_downloade
 - **`types.py`** : protocoles employés pour typer les objets YouTube.
 - **`legacy_utils.py`** : utilitaires généraux (compte à rebours, nettoyage de l’écran).
 
+La fonction `main()` peut recevoir un paramètre `cli_cls` pour instancier une
+classe dérivée de `CLI`. Cela permet d’étendre ou remplacer l’interface en ligne
+de commande sans modifier le reste du code.
+
 ## Schéma de fonctionnement
 
 ```mermaid

--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -113,6 +113,7 @@ def menu() -> None:  # pragma: no cover
 def main(
     argv: list[str] | None = None,
     downloader: YoutubeDownloader | None = None,
+    cli_cls: type[CLI] = CLI,
 ) -> None:
     """Entry point called by the ``program-youtube-downloader`` script.
 
@@ -125,7 +126,7 @@ def main(
     setup_logging(args.log_level)
     command = args.command
 
-    cli = CLI(downloader)
+    cli = cli_cls(downloader)
 
     if command is None or command == "menu":
         menu()

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -221,3 +221,19 @@ def test_main_menu_invocation(monkeypatch):
 def test_main_unknown_command():
     with pytest.raises(SystemExit):
         main_module.main(["unknown"])
+
+
+def test_main_custom_cli_class(monkeypatch, tmp_path):
+    dd = DummyDownloader()
+    called = {}
+
+    class DummyCLI(main_module.CLI):
+        def __init__(self, downloader=None):
+            super().__init__(downloader)
+            called["used"] = True
+
+    monkeypatch.setattr(main_module.cli_utils, "ask_save_file_path", lambda: tmp_path)
+    monkeypatch.setattr(main_module.cli_utils, "ask_resolution_or_bitrate", lambda *a, **k: 1)
+
+    main_module.main(["video", "https://youtu.be/x"], dd, DummyCLI)
+    assert called.get("used")


### PR DESCRIPTION
## Summary
- accept a `cli_cls` parameter in `main`
- instantiate that class instead of `CLI`
- document the extension point
- use the new param in a test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480a69b6408321860b54a586221014