### PR TITLE
Add guide for custom progress handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ consultez [AGENTS.md](AGENTS.md) à la racine du dépôt.
 - [docs/index.md](docs/index.md)
 - [docs/project-overview.md](docs/project-overview.md)
 - [docs/guides/](docs/guides/)
+- [docs/guides/custom-progress-handler.md](docs/guides/custom-progress-handler.md)
 - [docs/releases/](docs/releases/)
 - [docs/reference/api-reference.md](docs/reference/api-reference.md)
 - [docs/reference/architecture.md](docs/reference/architecture.md)

--- a/docs/guides/custom-progress-handler.md
+++ b/docs/guides/custom-progress-handler.md
@@ -1,0 +1,30 @@
+# Guide : gestionnaire de progression personnalisé
+
+Ce tutoriel explique comment créer et utiliser un gestionnaire de progression
+autre que ceux fournis dans `program_youtube_downloader.progress`.
+
+## Exemple minimal
+
+Le protocole `ProgressHandler` définit simplement la méthode
+`on_progress(event)`. Il suffit de fournir un objet possédant cette méthode
+pour recevoir les mises à jour :
+
+```python
+from pathlib import Path
+from program_youtube_downloader.downloader import YoutubeDownloader
+from program_youtube_downloader.config import DownloadOptions
+from program_youtube_downloader.progress import ProgressEvent, ProgressHandler
+
+class EmojiHandler:
+    def on_progress(self, event: ProgressEvent) -> None:
+        print(f"🍿 {event.percent:.0f}%")
+
+handler = EmojiHandler()
+yd = YoutubeDownloader(progress_handler=handler)
+options = DownloadOptions(save_path=Path("videos"))
+yd.download_multiple_videos(["https://youtu.be/example"], options)
+```
+
+`YoutubeDownloader` se charge d'enregistrer le callback auprès de `pytubefix` et
+convertit les notifications en objets `ProgressEvent`. Vous pouvez également
+passer le gestionnaire via `DownloadOptions(progress_handler=handler)`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,8 @@ Les différents dossiers de `docs/` sont organisés ainsi :
 ### 🧪 Tutoriels & Guides avancés
 - [`guides/download-video-guide.md`](guides/download-video-guide.md)
   > Guide pas à pas pour utiliser la CLI et télécharger une vidéo.
+- [`guides/custom-progress-handler.md`](guides/custom-progress-handler.md)
+  > Créer et enregistrer un gestionnaire de progression personnalisé.
 
 ---
 

--- a/tests/test_custom_progress.py
+++ b/tests/test_custom_progress.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from program_youtube_downloader.downloader import YoutubeDownloader
+from program_youtube_downloader.config import DownloadOptions
+from program_youtube_downloader import cli_utils
+from program_youtube_downloader.types import YouTubeVideo
+
+class DummyStream:
+    itag = 1
+    resolution = "360p"
+    abr = "128kbps"
+    default_filename = "sample.mp4"
+
+    def download(self, output_path: str) -> str:
+        p = Path(output_path) / self.default_filename
+        p.write_text("data")
+        return str(p)
+
+class DummyStreams(list):
+    def get_by_itag(self, itag: int) -> DummyStream:
+        return self[0]
+
+class DummyYT(YouTubeVideo):
+    def __init__(self, url: str) -> None:
+        self.url = url
+        self.streams: DummyStreams = DummyStreams([DummyStream()])
+        self.progress = None
+        self._title = "video"
+
+    @property
+    def title(self):
+        return self._title
+
+    def register_on_progress_callback(self, cb) -> None:
+        self.progress = cb
+
+class Recorder:
+    def __init__(self) -> None:
+        self.called = False
+
+    def on_progress(self, event) -> None:
+        self.called = True
+
+
+def test_constructor_custom_progress(monkeypatch, tmp_path: Path) -> None:
+    created = {}
+
+    def fake_constructor(url: str) -> DummyYT:
+        yt = DummyYT(url)
+        created["yt"] = yt
+        return yt
+
+    monkeypatch.setattr(YoutubeDownloader, "get_video_streams", lambda self, dso, yt: yt.streams)
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "")
+    monkeypatch.setattr(cli_utils, "print_end_download_message", lambda *a, **k: None)
+    monkeypatch.setattr(cli_utils, "pause_return_to_menu", lambda *a, **k: None)
+
+    handler = Recorder()
+    yd = YoutubeDownloader(progress_handler=handler, youtube_cls=fake_constructor)
+    options = DownloadOptions(save_path=tmp_path)
+
+    yd.download_multiple_videos(["https://youtu.be/x"], options)
+
+    assert (tmp_path / "sample.mp4").exists()
+    assert callable(created["yt"].progress)
+    created["yt"].progress(None, None, 0)
+    assert handler.called


### PR DESCRIPTION
## Summary
- document how to write a custom progress handler
- link new guide from README and docs index
- test usage when injecting the handler via the constructor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68480cd65e108321896dcfa18329d406