### PR TITLE
Use cli instance when running menu

### DIFF
--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -104,8 +104,10 @@ def handle_channel_option(cli: CLI, audio_only: bool) -> None:
 
 
 def menu() -> None:  # pragma: no cover
-    """Interactively ask the user what to download and start the process."""
+    """Interactively ask the user what to download.
 
+    Deprecated wrapper kept for backward compatibility.
+    """
     CLI().menu()
 
     
@@ -129,7 +131,7 @@ def main(
     cli = cli_cls(downloader)
 
     if command is None or command == "menu":
-        menu()
+        cli.menu()
         return
 
     yd = cli.downloader

--- a/tests/test_coverage_more.py
+++ b/tests/test_coverage_more.py
@@ -212,10 +212,15 @@ def test_main_channel_command(monkeypatch, tmp_path):
 
 def test_main_menu_invocation(monkeypatch):
     called = {}
-    monkeypatch.setattr(main_module, "menu", lambda: called.setdefault("menu", True))
-    monkeypatch.setattr(main_module, "YoutubeDownloader", lambda: DummyDownloader())
-    main_module.main(["menu"])
-    assert called.get("menu")
+
+    def fake_menu(self):
+        called["menu"] = self.downloader
+
+    monkeypatch.setattr(main_module.CLI, "menu", fake_menu)
+
+    dd = DummyDownloader()
+    main_module.main(["menu"], dd)
+    assert called["menu"] is dd
 
 
 def test_main_unknown_command():

--- a/tests/test_menu_integration.py
+++ b/tests/test_menu_integration.py
@@ -12,13 +12,12 @@ class DummyDownloader:
 
 def run_menu_with_choice(monkeypatch, tmp_path, menu_choice):
     dd = DummyDownloader()
-    monkeypatch.setattr(cli_module, "YoutubeDownloader", lambda: dd)
     monkeypatch.setattr(cli_module.cli_utils, "display_main_menu", lambda: len(cli_module.MenuOption))
     choices = iter([menu_choice, cli_module.MenuOption.QUIT.value])
     monkeypatch.setattr(cli_module.cli_utils, "ask_numeric_value", lambda a, b: next(choices))
     monkeypatch.setattr(cli_module.cli_utils, "ask_youtube_url", lambda: "https://youtu.be/x")
     monkeypatch.setattr(cli_module.CLI, "create_download_options", lambda self, ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
-    cli_module.CLI().menu()
+    cli_module.CLI(dd).menu()
     return dd.called
 
 


### PR DESCRIPTION
## Summary
- call `cli.menu()` directly from `main`
- keep `menu()` wrapper only for backwards compatibility
- adjust menu integration tests to pass custom downloader
- update coverage test to verify downloader usage via CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684811f0b2ec8321bcfb5d0175f4499e