### PR TITLE
Handle menu command with provided downloader

### DIFF
--- a/program_youtube_downloader/main.py
+++ b/program_youtube_downloader/main.py
@@ -106,9 +106,10 @@ def handle_channel_option(cli: CLI, audio_only: bool) -> None:
 def menu() -> None:  # pragma: no cover
     """Interactively ask the user what to download.
 
-    Deprecated wrapper kept for backward compatibility.
+    Deprecated wrapper kept for backward compatibility. It now
+    simply forwards to :func:`main` with the ``"menu"`` command.
     """
-    CLI().menu()
+    main(["menu"])  # type: ignore[arg-type]
 
     
 

--- a/tests/test_menu_integration.py
+++ b/tests/test_menu_integration.py
@@ -1,4 +1,5 @@
 import program_youtube_downloader.cli as cli_module
+import program_youtube_downloader.main as main_module
 from program_youtube_downloader.config import DownloadOptions
 
 
@@ -12,12 +13,12 @@ class DummyDownloader:
 
 def run_menu_with_choice(monkeypatch, tmp_path, menu_choice):
     dd = DummyDownloader()
-    monkeypatch.setattr(cli_module.cli_utils, "display_main_menu", lambda: len(cli_module.MenuOption))
+    monkeypatch.setattr(main_module.cli_utils, "display_main_menu", lambda: len(cli_module.MenuOption))
     choices = iter([menu_choice, cli_module.MenuOption.QUIT.value])
-    monkeypatch.setattr(cli_module.cli_utils, "ask_numeric_value", lambda a, b: next(choices))
-    monkeypatch.setattr(cli_module.cli_utils, "ask_youtube_url", lambda: "https://youtu.be/x")
-    monkeypatch.setattr(cli_module.CLI, "create_download_options", lambda self, ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
-    cli_module.CLI(dd).menu()
+    monkeypatch.setattr(main_module.cli_utils, "ask_numeric_value", lambda a, b: next(choices))
+    monkeypatch.setattr(main_module.cli_utils, "ask_youtube_url", lambda: "https://youtu.be/x")
+    monkeypatch.setattr(main_module.CLI, "create_download_options", lambda self, ao: DownloadOptions(save_path=tmp_path, download_sound_only=ao))
+    main_module.main(["menu"], dd)
     return dd.called
 
 


### PR DESCRIPTION
## Summary
- route `menu()` to `main(["menu"])`
- run menu flow through `main()` in integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848144301b883219f939efa3bc89b68