### PR TITLE
Support KeyboardInterrupt in CLI menu

### DIFF
--- a/program_youtube_downloader/cli.py
+++ b/program_youtube_downloader/cli.py
@@ -115,36 +115,42 @@ class CLI:
     # ------------------------------------------------------------------
     def menu(self) -> None:  # pragma: no cover - manual user interaction
         """Interactively ask the user what to download and start the process."""
-        while True:
-            choix_max_menu_accueil = cli_utils.display_main_menu()
-            choix = MenuOption(cli_utils.ask_numeric_value(1, choix_max_menu_accueil))
+        try:
+            while True:
+                choix_max_menu_accueil = cli_utils.display_main_menu()
+                choix = MenuOption(
+                    cli_utils.ask_numeric_value(1, choix_max_menu_accueil)
+                )
 
-            match choix:
-                case MenuOption.QUIT:
-                    self.handle_quit_option()
-                    break
-                case MenuOption.VIDEO:
-                    self.handle_video_option(False)
-                case MenuOption.VIDEO_AUDIO_ONLY:
-                    self.handle_video_option(True)
-                case MenuOption.VIDEOS:
-                    self.handle_videos_option(False)
-                case MenuOption.VIDEOS_AUDIO_ONLY:
-                    self.handle_videos_option(True)
-                case MenuOption.PLAYLIST_VIDEO:
-                    self.handle_playlist_option(False)
-                case MenuOption.PLAYLIST_AUDIO_ONLY:
-                    self.handle_playlist_option(True)
-                case MenuOption.CHANNEL_VIDEOS:
-                    self.handle_channel_option(False)
-                case MenuOption.CHANNEL_AUDIO_ONLY:
-                    self.handle_channel_option(True)
+                match choix:
+                    case MenuOption.QUIT:
+                        self.handle_quit_option()
+                        break
+                    case MenuOption.VIDEO:
+                        self.handle_video_option(False)
+                    case MenuOption.VIDEO_AUDIO_ONLY:
+                        self.handle_video_option(True)
+                    case MenuOption.VIDEOS:
+                        self.handle_videos_option(False)
+                    case MenuOption.VIDEOS_AUDIO_ONLY:
+                        self.handle_videos_option(True)
+                    case MenuOption.PLAYLIST_VIDEO:
+                        self.handle_playlist_option(False)
+                    case MenuOption.PLAYLIST_AUDIO_ONLY:
+                        self.handle_playlist_option(True)
+                    case MenuOption.CHANNEL_VIDEOS:
+                        self.handle_channel_option(False)
+                    case MenuOption.CHANNEL_AUDIO_ONLY:
+                        self.handle_channel_option(True)
 
 
 
 
             # end match
         # end while
+        except KeyboardInterrupt:
+            self.handle_quit_option()
+            return
 
 
 __all__ = ["CLI"]

--- a/tests/test_menu_integration.py
+++ b/tests/test_menu_integration.py
@@ -32,3 +32,20 @@ def test_menu_audio_only_triggers_download(monkeypatch, tmp_path):
     called = run_menu_with_choice(monkeypatch, tmp_path, cli_module.MenuOption.VIDEO_AUDIO_ONLY.value)
     assert called[0] == ["https://youtu.be/x"]
     assert called[1].download_sound_only is True
+
+
+def test_menu_keyboard_interrupt(monkeypatch):
+    dd = DummyDownloader()
+    monkeypatch.setattr(
+        main_module.cli_utils,
+        "display_main_menu",
+        lambda: len(cli_module.MenuOption),
+    )
+
+    def raise_interrupt(*args, **kwargs):
+        raise KeyboardInterrupt()
+
+    monkeypatch.setattr(
+        main_module.cli_utils, "ask_numeric_value", raise_interrupt
+    )
+    main_module.main(["menu"], dd)


### PR DESCRIPTION
## Summary
- wrap `CLI.menu` loop in a `try`/`except KeyboardInterrupt`
- call `handle_quit_option()` when Ctrl+C is pressed
- test menu behaviour on `KeyboardInterrupt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684815fece688321a710aacb06f565db