### PR TITLE
Refactor logging blank lines

### DIFF
--- a/program_youtube_downloader/__init__.py
+++ b/program_youtube_downloader/__init__.py
@@ -1,7 +1,7 @@
 """Public exports for program_youtube_downloader."""
 from .exceptions import PydlError, DownloadError, ValidationError
 # re-export utilities
-from .utils import clear_screen, program_break_time, shorten_url
+from .utils import clear_screen, program_break_time, shorten_url, log_blank_line
 
 __all__ = [
     "PydlError",
@@ -10,4 +10,5 @@ __all__ = [
     "clear_screen",
     "program_break_time",
     "shorten_url",
+    "log_blank_line",
 ]

--- a/program_youtube_downloader/cli.py
+++ b/program_youtube_downloader/cli.py
@@ -13,6 +13,7 @@ from .downloader import YoutubeDownloader
 from .exceptions import PlaylistConnectionError, ChannelConnectionError
 from .config import DownloadOptions
 from .constants import MenuOption
+from .utils import log_blank_line
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +52,8 @@ class CLI:
     # ------------------------------------------------------------------
     def handle_quit_option(self) -> None:
         """Display the exit banner."""
-        logger.info("")
-        logger.info("")
+        log_blank_line()
+        log_blank_line()
         logger.info("******************************************************")
         logger.info("*                                                    *")
         logger.info("*                    Fin du programme                *")

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -11,7 +11,7 @@ from .constants import (
     TITLE_QUESTION_MENU_ACCUEIL,
     CHOICE_MENU_ACCUEIL,
 )
-from .utils import program_break_time, clear_screen
+from .utils import program_break_time, clear_screen, log_blank_line
 from .validators import validate_youtube_url
 
 logger = logging.getLogger(__name__)
@@ -47,7 +47,7 @@ def ask_numeric_value(min_value: int, max_value: int, max_attempts: int = 3) -> 
             v_int = int(v_str)
         except ValueError:
             logger.warning("Entrée invalide : saisissez une valeur numérique.")
-            logger.info("")
+            log_blank_line()
             attempts += 1
             if attempts >= max_attempts:
                 raise ValidationError("Nombre de tentatives dépassé")
@@ -57,7 +57,7 @@ def ask_numeric_value(min_value: int, max_value: int, max_attempts: int = 3) -> 
                 "Entrée invalide : saisissez un nombre entre "
                 f"{min_value} et {max_value}."
             )
-            logger.info("")
+            log_blank_line()
             attempts += 1
             if attempts >= max_attempts:
                 raise ValidationError("Nombre de tentatives dépassé")
@@ -308,10 +308,10 @@ def ask_resolution_or_bitrate(
 
 def print_end_download_message() -> None:
     """Print a short message indicating that all downloads completed."""
-    logger.info("")
+    log_blank_line()
     logger.info("Fin du téléchargement")
     print_separator()
-    logger.info("")
+    log_blank_line()
 
 
 def pause_return_to_menu() -> None:

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -15,7 +15,7 @@ from .progress import (
     ProgressBarHandler,
     create_progress_event,
 )
-from .utils import shorten_url
+from .utils import shorten_url, log_blank_line
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ class YoutubeDownloader:
         for attempt in range(3):
             try:
                 out_file = Path(stream.download(output_path=str(save_path)))
-                logger.info("")
+                log_blank_line()
                 break
             except (
                 HTTPError,
@@ -120,18 +120,18 @@ class YoutubeDownloader:
                 PytubeError,
             ) as e:  # pragma: no cover - network/io issues
                 logger.exception("Échec du téléchargement")
-                logger.info("")
+                log_blank_line()
                 logger.error(f"Le téléchargement a échoué : {e}")
-                logger.info("")
+                log_blank_line()
                 if attempt == 2:
                     raise DownloadError(
                         f"Echec du téléchargement pour {video_url}"
                     ) from e
             except Exception as e:  # pragma: no cover - defensive
                 logger.exception("Erreur inattendue pendant le téléchargement")
-                logger.info("")
+                log_blank_line()
                 logger.error(f"Le téléchargement a échoué : {e}")
-                logger.info("")
+                log_blank_line()
                 if attempt == 2:
                     raise DownloadError(
                         f"Echec du téléchargement pour {video_url}"
@@ -210,7 +210,7 @@ class YoutubeDownloader:
             logger.warning("Un fichier MP3 portant le même nom existe déjà")
             if file_path.exists():
                 file_path.unlink()
-            logger.info("")
+            log_blank_line()
 
     def _prepare_video(
         self,
@@ -365,8 +365,8 @@ class YoutubeDownloader:
                         choice_callback,
                     )
                     choice_once = False
-                    logger.info("")
-                    logger.info("")
+                    log_blank_line()
+                    log_blank_line()
                     cli_utils.print_separator()
                     logger.info("*             Stream vidéo sélectionné :          *")
                     cli_utils.print_separator()
@@ -374,7 +374,7 @@ class YoutubeDownloader:
                         "Nombre de liens vidéo YouTube dans le fichier : "
                         f"{len(url_list)}"
                     )
-                    logger.info("")
+                    log_blank_line()
 
                 itag = streams[choice_user - 1].itag  # type: ignore
                 stream = youtube_video.streams.get_by_itag(itag)

--- a/program_youtube_downloader/utils.py
+++ b/program_youtube_downloader/utils.py
@@ -8,9 +8,14 @@ import time
 import logging
 from urllib.parse import urlparse, parse_qs
 
-__all__ = ["clear_screen", "program_break_time", "shorten_url"]
+__all__ = ["clear_screen", "program_break_time", "shorten_url", "log_blank_line"]
 
 logger = logging.getLogger(__name__)
+
+
+def log_blank_line() -> None:
+    """Insert a blank line in the logs."""
+    logger.info("")
 
 
 def clear_screen() -> None:


### PR DESCRIPTION
## Summary
- add `log_blank_line()` helper function
- use `log_blank_line()` instead of direct `logger.info("")` calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848184b69c88321a8d2ba874a468c07