### PR TITLE
Unify French messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Ce projet est destiné à un usage personnel pour faciliter la récupération de
 ## Journalisation
 
 L'outil utilise le module `logging` de Python pour afficher les messages d'erreur.
+Tous les messages affichés dans la console ou dans les journaux sont rédigés en
+**français** afin de conserver une interface cohérente.
 Par défaut, seuls les messages de niveau `ERROR` sont affichés. Vous pouvez
 activer un niveau plus verbeux de deux manières&nbsp;:
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -30,6 +30,12 @@ Le cœur de l’application se trouve dans le package `program_youtube_downloade
 - **`types.py`** : protocoles employés pour typer les objets YouTube.
 - **`legacy_utils.py`** : utilitaires généraux (compte à rebours, nettoyage de l’écran).
 
+### Convention de langue
+
+Tous les messages affichés par la CLI et les journaux sont écrits en **français**. Les modules
+`cli.py`, `cli_utils.py`, `downloader.py` et `progress.py` respectent cette règle
+pour garantir une expérience cohérente.
+
 La fonction `main()` peut recevoir un paramètre `cli_cls` pour instancier une
 classe dérivée de `CLI`. Cela permet d’étendre ou remplacer l’interface en ligne
 de commande sans modifier le reste du code.

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -125,7 +125,7 @@ def ask_save_file_path(max_attempts: int = 3) -> Path:
                 try:
                     path.mkdir(parents=True, exist_ok=True)
                 except OSError:
-                    logger.exception("Directory creation failed")
+                    logger.exception("Échec de la création du dossier")
                     logger.error("Impossible de créer le dossier")
                     attempts += 1
                     if attempts >= max_attempts:

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -32,7 +32,7 @@ def create_progress_event(stream, bytes_remaining) -> ProgressEvent:
     """Return a :class:`ProgressEvent` from pytube callback arguments."""
     total = getattr(stream, "filesize", None)
     if not total:
-        logger.warning("Missing total filesize. Assuming complete")
+        logger.warning("Taille totale manquante. Supposée complète")
         percent = 100.0
         downloaded = total or 0
         total = total or 0
@@ -58,8 +58,8 @@ class ProgressOptions:
     sides: str = "||"
     full: str = "█"
     empty: str = " "
-    prefix_start: str = "Downloading ..."
-    prefix_end: str = "Download OK ..."
+    prefix_start: str = "Téléchargement en cours ..."
+    prefix_end: str = "Téléchargement terminé ..."
     color_text: str = colorama.Fore.WHITE
     color_Downloading: str = colorama.Fore.LIGHTYELLOW_EX
     color_Download_OK: str = colorama.Fore.GREEN

--- a/tests/test_cli_utils.py
+++ b/tests/test_cli_utils.py
@@ -1,3 +1,4 @@
+import logging
 import pytest
 from pathlib import Path
 
@@ -73,7 +74,7 @@ def test_ask_save_file_path_retry(monkeypatch, tmp_path):
     assert p == existing.resolve()
 
 
-def test_ask_save_file_path_mkdir_failure(monkeypatch, tmp_path):
+def test_ask_save_file_path_mkdir_failure(monkeypatch, tmp_path, caplog):
     new_dir = tmp_path / "newdir"
     inputs = iter([str(new_dir), "y", str(tmp_path)])
     monkeypatch.setattr("builtins.input", lambda *a, **k: next(inputs))
@@ -85,8 +86,10 @@ def test_ask_save_file_path_mkdir_failure(monkeypatch, tmp_path):
     fail_once.calls = 0
     monkeypatch.setattr(Path, "mkdir", fail_once)
 
-    result = cli_utils.ask_save_file_path()
+    with caplog.at_level(logging.ERROR):
+        result = cli_utils.ask_save_file_path()
     assert result == tmp_path.resolve()
+    assert "Échec de la création du dossier" in caplog.text
 
 
 def test_ask_save_file_path_dircreation_error(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- translate remaining English log messages in `cli_utils` and `progress`
- assert French wording in `test_ask_save_file_path_mkdir_failure`
- mention the French message convention in the docs

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481aa488d88321b35e3e82d07d6285