### PR TITLE
Add guide for extending CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ consultez [AGENTS.md](AGENTS.md) à la racine du dépôt.
 - [docs/project-overview.md](docs/project-overview.md)
 - [docs/guides/](docs/guides/)
 - [docs/guides/custom-progress-handler.md](docs/guides/custom-progress-handler.md)
+- [docs/guides/custom-cli-class.md](docs/guides/custom-cli-class.md)
 - [docs/releases/](docs/releases/)
 - [docs/reference/api-reference.md](docs/reference/api-reference.md)
 - [docs/reference/architecture.md](docs/reference/architecture.md)

--- a/docs/guides/custom-cli-class.md
+++ b/docs/guides/custom-cli-class.md
@@ -1,0 +1,34 @@
+# Guide : étendre la classe CLI
+
+Ce tutoriel explique comment dériver `CLI` afin d'ajouter de nouvelles options ou d'adapter le menu interactif.
+La fonction `main()` accepte un argument `cli_cls` pour instancier cette classe personnalisée.
+
+## Exemple minimal
+
+```python
+from program_youtube_downloader import cli_utils
+from program_youtube_downloader.cli import CLI
+from program_youtube_downloader.main import main
+
+class MyCLI(CLI):
+    def handle_hello_option(self) -> None:
+        print("Bonjour !")
+
+    def menu(self) -> None:
+        while True:
+            print("1 - Dire bonjour")
+            print("0 - Quitter")
+            choice = cli_utils.ask_numeric_value(0, 1)
+            if choice == 0:
+                self.handle_quit_option()
+                break
+            else:
+                self.handle_hello_option()
+```
+
+```python
+if __name__ == "__main__":
+    main(cli_cls=MyCLI)
+```
+
+Ici `MyCLI` hérite de `CLI` pour ajouter une nouvelle entrée de menu. La fonction `main()` lancera cette classe et utilisera ses méthodes comme si elles faisaient partie de l'interface originale.

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,9 @@ Les différents dossiers de `docs/` sont organisés ainsi :
 - [`guides/download-video-guide.md`](guides/download-video-guide.md)
   > Guide pas à pas pour utiliser la CLI et télécharger une vidéo.
 - [`guides/custom-progress-handler.md`](guides/custom-progress-handler.md)
-  > Créer et enregistrer un gestionnaire de progression personnalisé.
+  > Créer et enregistrer un gestionnaire de progression personnalisé.
+- [`guides/custom-cli-class.md`](guides/custom-cli-class.md)
+  > Étendre la classe `CLI` pour ajouter de nouvelles options.
 
 ---
 


### PR DESCRIPTION
## Summary
- document how to subclass `CLI` and inject it in `main`
- link new guide from index and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68481d7019808321be23f15bc05d5206