### PR TITLE
Améliore journalisation URL

### DIFF
--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -119,18 +119,32 @@ class YoutubeDownloader:
                 OSError,
                 PytubeError,
             ) as e:  # pragma: no cover - network/io issues
-                logger.exception("Échec du téléchargement")
+                logger.exception(
+                    "Échec du téléchargement pour %s",
+                    shorten_url(video_url),
+                )
                 log_blank_line()
-                logger.error(f"Le téléchargement a échoué : {e}")
+                logger.error(
+                    "Le téléchargement de %s a échoué : %s",
+                    shorten_url(video_url),
+                    e,
+                )
                 log_blank_line()
                 if attempt == 2:
                     raise DownloadError(
                         f"Echec du téléchargement pour {video_url}"
                     ) from e
             except Exception as e:  # pragma: no cover - defensive
-                logger.exception("Erreur inattendue pendant le téléchargement")
+                logger.exception(
+                    "Erreur inattendue pendant le téléchargement de %s",
+                    shorten_url(video_url),
+                )
                 log_blank_line()
-                logger.error(f"Le téléchargement a échoué : {e}")
+                logger.error(
+                    "Le téléchargement de %s a échoué : %s",
+                    shorten_url(video_url),
+                    e,
+                )
                 log_blank_line()
                 if attempt == 2:
                     raise DownloadError(
@@ -251,14 +265,25 @@ class YoutubeDownloader:
             )
             return None
         except PytubeError as e:
-            logger.exception("Erreur lors de l'accès au titre de la vidéo")
+            logger.exception(
+                "Erreur lors de l'accès au titre de la vidéo %s",
+                shorten_url(video_url),
+            )
             logger.error(
-                f"Une erreur est survenue lors de l'accès au titre : {e}"
+                "Une erreur est survenue lors de l'accès au titre de %s : %s",
+                shorten_url(video_url),
+                e,
             )
             return None
-        except Exception:  # pragma: no cover - defensive
+        except Exception as e:  # pragma: no cover - defensive
             logger.exception(
-                "Erreur inattendue lors de l'accès au titre de la vidéo"
+                "Erreur inattendue lors de l'accès au titre de la vidéo %s",
+                shorten_url(video_url),
+            )
+            logger.error(
+                "Une erreur inattendue s'est produite lors de l'accès au titre de %s : %s",
+                shorten_url(video_url),
+                e,
             )
             return None
 

--- a/tests/test_additional.py
+++ b/tests/test_additional.py
@@ -318,3 +318,20 @@ def test_download_multiple_videos_download_error(monkeypatch, tmp_path, caplog):
         yd.download_multiple_videos(["https://youtu.be/fail"], options)
     assert "fail" in caplog.text
     assert not any(tmp_path.iterdir())
+
+
+def test_download_video_error_logs_url(tmp_path, caplog):
+    """_download_video should mention the URL in error messages."""
+
+    class FailingStream(DummyStream):
+        def download(self, output_path: str) -> str:
+            raise OSError("boom")
+
+    stream = FailingStream()
+    yd = YoutubeDownloader()
+
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(DownloadError):
+            yd._download_video(stream, tmp_path, "https://youtu.be/boom", False)
+
+    assert "boom" in caplog.text


### PR DESCRIPTION
## Summary
- include video URL in `_download_video` error logs
- include video URL in `_prepare_video` error logs
- verify url presence in logs when download errors occur

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68482080d1988321ab414e27bcf19a9c