### PR TITLE
Extract separator constant

### DIFF
--- a/program_youtube_downloader/cli.py
+++ b/program_youtube_downloader/cli.py
@@ -14,7 +14,7 @@ from .types import ConsoleIO, DefaultConsoleIO
 from .downloader import YoutubeDownloader
 from .exceptions import PlaylistConnectionError, ChannelConnectionError
 from .config import DownloadOptions
-from .constants import MenuOption
+from .constants import MenuOption, SEPARATOR
 from .utils import log_blank_line
 
 logger = logging.getLogger(__name__)
@@ -64,11 +64,11 @@ class CLI:
         """Display the exit banner."""
         log_blank_line()
         log_blank_line()
-        logger.info("******************************************************")
+        logger.info(SEPARATOR)
         logger.info("*                                                    *")
         logger.info("*                    Fin du programme                *")
         logger.info("*                                                    *")
-        logger.info("******************************************************")
+        logger.info(SEPARATOR)
 
     def handle_video_option(self, audio_only: bool) -> None:
         """Download a single video or its audio track."""

--- a/program_youtube_downloader/cli_utils.py
+++ b/program_youtube_downloader/cli_utils.py
@@ -12,6 +12,7 @@ from .constants import (
     TITLE_PROGRAM,
     TITLE_QUESTION_MENU_ACCUEIL,
     CHOICE_MENU_ACCUEIL,
+    SEPARATOR,
 )
 from .utils import program_break_time, clear_screen, log_blank_line
 from .validators import validate_youtube_url
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 def print_separator(console: ConsoleIO = DefaultConsoleIO()) -> None:
     """Print a decorative separator line used in menus."""
-    console.print("*************************************************************")
+    console.print(SEPARATOR)
 
 
 def ask_numeric_value(

--- a/program_youtube_downloader/constants.py
+++ b/program_youtube_downloader/constants.py
@@ -2,6 +2,9 @@
 
 from enum import Enum
 
+# Visual separator used in menus and logs
+SEPARATOR = "*************************************************************"
+
 TITLE_PROGRAM = "Program Youtube Downloader"
 
 TITLE_QUESTION_MENU_ACCUEIL = "Que voulez-vous télécharger sur Youtube ?"
@@ -41,4 +44,5 @@ __all__ = [
     "CHOICE_MENU_ACCUEIL",
     "MenuOption",
     "BASE_YOUTUBE_URL",
+    "SEPARATOR",
 ]


### PR DESCRIPTION
## Summary
- centralize separator line in `constants.py`
- use `constants.SEPARATOR` in `cli_utils.print_separator`
- reuse the separator constant in the CLI exit banner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483596ed58832196c386a3d4b7270c