### PR TITLE
Add type checking and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install .
+          pip install mypy flake8 pytest
+      - name: Run flake8
+        run: flake8
+      - name: Run mypy
+        run: mypy program_youtube_downloader
+      - name: Run tests
+        run: pytest

--- a/docs/guides/contributing.md
+++ b/docs/guides/contributing.md
@@ -28,6 +28,17 @@ PYDL_LOG_LEVEL=DEBUG pytest
 PYDL_MAX_WORKERS=2 pytest
 ```
 
+## Vérification du style et des types
+
+Avant de proposer vos modifications, assurez-vous que le code respecte les
+conventions du projet :
+
+```bash
+flake8
+mypy program_youtube_downloader
+```
+
+
 # Module logging
 Ce projet utilise le module `logging` de Python pour signaler l'état et les erreurs. Lors de l'ajout de nouveaux messages :
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,5 @@
 [mypy]
+python_version = 3.10
 ignore_missing_imports = True
+disallow_untyped_defs = True
+check_untyped_defs = True

--- a/program_youtube_downloader/downloader.py
+++ b/program_youtube_downloader/downloader.py
@@ -59,7 +59,7 @@ class YoutubeDownloader:
         try:
             yt = self.youtube_cls(url)
             if progress_handler:
-                def _wrapper(stream, chunk, bytes_remaining):
+                def _wrapper(stream: Any, chunk: bytes, bytes_remaining: int) -> None:
                     """Translate pytube progress callback to :class:`ProgressEvent`."""
                     event = create_progress_event(stream, bytes_remaining)
                     progress_handler.on_progress(event)

--- a/program_youtube_downloader/progress.py
+++ b/program_youtube_downloader/progress.py
@@ -1,6 +1,6 @@
 import sys
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, Any
 import logging
 
 import colorama
@@ -28,7 +28,7 @@ class ProgressEvent:
     percent: float
 
 
-def create_progress_event(stream, bytes_remaining) -> ProgressEvent:
+def create_progress_event(stream: Any, bytes_remaining: int) -> ProgressEvent:
     """Return a :class:`ProgressEvent` from pytube callback arguments."""
     total = getattr(stream, "filesize", None)
     if not total:
@@ -43,7 +43,7 @@ def create_progress_event(stream, bytes_remaining) -> ProgressEvent:
 
 
 def on_download_progress(
-    stream, chunk, bytes_remaining
+    stream: Any, chunk: bytes, bytes_remaining: int
 ) -> None:  # pragma: no cover - legacy
     """Backward compatible wrapper around :class:`ProgressBarHandler`."""
     event = create_progress_event(stream, bytes_remaining)

--- a/program_youtube_downloader/types.py
+++ b/program_youtube_downloader/types.py
@@ -1,4 +1,4 @@
-from typing import Protocol, Any
+from typing import Protocol, Any, Callable
 
 
 class ConsoleIO(Protocol):
@@ -32,7 +32,9 @@ class YouTubeVideo(Protocol):
 
         ...
 
-    def register_on_progress_callback(self, cb) -> None:  # pragma: no cover - typing stub
+    def register_on_progress_callback(
+        self, cb: Callable[[Any, bytes, int], None]
+    ) -> None:  # pragma: no cover - typing stub
         """Register a callback invoked during downloads."""
 
         ...


### PR DESCRIPTION
## Summary
- enforce typed functions in `mypy.ini`
- document style/type checking in contributing guide
- annotate callbacks and wrappers with type hints
- add GitHub Actions workflow to run `flake8`, `mypy` and `pytest`

## Testing
- `flake8`
- `mypy program_youtube_downloader`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483cec14748321b84ad2ae39e6b3c4