### PR TITLE
Fix test parsing of pyproject on Python 3.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pytubefix==9.1.1 # test de la version
 # pytubefix==8.12.0
 pywin32-ctypes==0.2.3
 pytest==8.4.0  # development dependency
+tomli; python_version < "3.11"

--- a/tests/test_install_launch.py
+++ b/tests/test_install_launch.py
@@ -2,7 +2,11 @@ import os
 import sys
 import subprocess
 from pathlib import Path
-import tomllib
+
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
 
 
 def test_console_script_defined() -> None:


### PR DESCRIPTION
## Summary
- require `tomli` when Python < 3.11
- make tests import `tomllib` with fallback to `tomli`

## Testing
- `flake8`
- `mypy program_youtube_downloader`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684844c1b0ac832182876b1850064674