### PR TITLE
Add tomli for Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = "MIT"
 dependencies = [
     "pytubefix",
     "colorama",
+    "tomli; python_version < \"3.11\"",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ pytubefix==9.1.1 # test de la version
 # pytubefix==8.12.0
 pywin32-ctypes==0.2.3
 pytest==8.4.0  # development dependency
-tomli; python_version < "3.11"
+tomli; python_version < "3.11"  # development dependency

--- a/tests/test_install_launch.py
+++ b/tests/test_install_launch.py
@@ -3,9 +3,9 @@ import sys
 import subprocess
 from pathlib import Path
 
-try:  # Python 3.11+
+try:
     import tomllib
-except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+except ModuleNotFoundError:
     import tomli as tomllib
 
 


### PR DESCRIPTION
## Summary
- ensure pyproject is parsed with tomli on Python 3.10
- mark tomli as a dev dependency

## Testing
- `python3 -m flake8`
- `mypy program_youtube_downloader`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68484aed039c832181a8a48516502928