### PR TITLE
Support env options for defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,23 @@ en définissant la variable d'environnement `PYDL_MAX_WORKERS` :
 PYDL_MAX_WORKERS=4 program-youtube-downloader video https://youtu.be/example
 ```
 
+De même, `PYDL_OUTPUT_DIR` permet de choisir un dossier de sortie par défaut et
+`PYDL_AUDIO_ONLY` d'activer automatiquement le téléchargement de la piste
+audio :
+
+```bash
+PYDL_OUTPUT_DIR=/chemin/de/sortie PYDL_AUDIO_ONLY=1 \
+    program-youtube-downloader video https://youtu.be/example
+```
+
 ## Variables d'environnement
 
-Le programme peut être configuré via deux variables principales :
+Le programme peut être configuré via plusieurs variables :
 
 - **`PYDL_LOG_LEVEL`** détermine le niveau de verbosité du module `logging`. En l'absence de cette variable, le niveau `ERROR` est utilisé.
 - **`PYDL_MAX_WORKERS`** fixe le nombre maximal de téléchargements lancés en parallèle. Une valeur trop élevée peut ralentir la connexion.
+- **`PYDL_OUTPUT_DIR`** définit le dossier de destination par défaut.
+- **`PYDL_AUDIO_ONLY`** force le téléchargement de la piste audio si sa valeur est ``1`` ou ``true``.
 
 Ces paramètres sont lus lors de la création des `DownloadOptions`. Consultez la [partie configuration](docs/reference/api-reference.md#configpy) pour les détails sur le comportement associé.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -57,3 +57,12 @@ graph TD
 3. `YoutubeDownloader` télécharge les flux grâce à `pytubefix` puis enregistre le fichier.
 4. Si l’option audio est activée, le fichier MP4 est converti en MP3 via `conversion_mp4_in_mp3`.
 5. Une barre de progression s’affiche durant le téléchargement et un message signale la fin de l’opération.
+
+## Variables d'environnement
+
+Certaines options peuvent être définies via le système pour éviter de les
+passer à chaque exécution :
+
+- `PYDL_MAX_WORKERS` pour contrôler le nombre de téléchargements parallèles ;
+- `PYDL_OUTPUT_DIR` pour choisir le dossier de sortie par défaut ;
+- `PYDL_AUDIO_ONLY` pour activer automatiquement le mode audio.

--- a/program_youtube_downloader/config.py
+++ b/program_youtube_downloader/config.py
@@ -1,20 +1,45 @@
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Callable, Any
+from typing import Optional, Callable, Any, TypeVar
 import os
 
 from .progress import ProgressHandler
 
+T = TypeVar("T")
+
+
+def _option_from_env(name: str, converter: Callable[[str], T], default: T) -> T:
+    """Return ``name`` converted by ``converter`` or ``default`` on error."""
+    value = os.getenv(name)
+    if value is None:
+        return default
+    try:
+        return converter(value)
+    except Exception:
+        return default
+
 
 def _max_workers_from_env() -> int:
     """Return ``PYDL_MAX_WORKERS`` as an integer or fallback to ``1``."""
-    value = os.getenv("PYDL_MAX_WORKERS")
-    if value is None:
-        return 1
-    try:
-        return int(value)
-    except ValueError:
-        return 1
+    return _option_from_env("PYDL_MAX_WORKERS", int, 1)
+
+
+def _output_dir_from_env() -> Optional[Path]:
+    """Return ``PYDL_OUTPUT_DIR`` as a ``Path`` or ``None``."""
+    return _option_from_env(
+        "PYDL_OUTPUT_DIR",
+        lambda p: Path(p).expanduser().resolve(),
+        None,
+    )
+
+
+def _audio_only_from_env() -> bool:
+    """Return ``PYDL_AUDIO_ONLY`` as a boolean."""
+    return _option_from_env(
+        "PYDL_AUDIO_ONLY",
+        lambda v: v.strip().lower() in {"1", "true", "yes", "on"},
+        False,
+    )
 
 
 @dataclass
@@ -36,8 +61,8 @@ class DownloadOptions:
             ``PYDL_MAX_WORKERS`` environment variable, defaulting to ``1``.
     """
 
-    save_path: Optional[Path] = None
-    download_sound_only: bool = False
+    save_path: Optional[Path] = field(default_factory=_output_dir_from_env)
+    download_sound_only: bool = field(default_factory=_audio_only_from_env)
     choice_callback: Optional[Callable[[bool, Any], int]] = None
     progress_handler: Optional[ProgressHandler] = None
     max_workers: int = field(default_factory=_max_workers_from_env)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from program_youtube_downloader.config import DownloadOptions
 
 
@@ -17,3 +19,27 @@ def test_max_workers_env_default(monkeypatch):
     monkeypatch.delenv("PYDL_MAX_WORKERS", raising=False)
     opts = DownloadOptions()
     assert opts.max_workers == 1
+
+
+def test_output_dir_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYDL_OUTPUT_DIR", str(tmp_path))
+    opts = DownloadOptions()
+    assert opts.save_path == tmp_path.resolve()
+
+
+def test_output_dir_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("PYDL_OUTPUT_DIR", str(tmp_path / "env"))
+    opts = DownloadOptions(save_path=tmp_path)
+    assert opts.save_path == tmp_path
+
+
+def test_audio_only_env(monkeypatch):
+    monkeypatch.setenv("PYDL_AUDIO_ONLY", "1")
+    opts = DownloadOptions()
+    assert opts.download_sound_only is True
+
+
+def test_audio_only_default(monkeypatch):
+    monkeypatch.delenv("PYDL_AUDIO_ONLY", raising=False)
+    opts = DownloadOptions()
+    assert opts.download_sound_only is False


### PR DESCRIPTION
## Summary
- generalize environment variable parsing
- default `DownloadOptions.save_path` and `download_sound_only` from `PYDL_OUTPUT_DIR` and `PYDL_AUDIO_ONLY`
- document new environment variables
- test configuration helpers

## Testing
- `pre-commit run --files program_youtube_downloader/config.py tests/test_config.py README.md docs/reference/architecture.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848828398588321b54d6b3a77126830